### PR TITLE
fix: resolve puppeteer lint warning

### DIFF
--- a/example/web_page_weather/judge.ts
+++ b/example/web_page_weather/judge.ts
@@ -1,7 +1,7 @@
 import { DecisionCode, parseArgs, printTestCaseResult, startHttpServer } from '@exercode/problem-utils';
 import type { TestCaseResult } from '@exercode/problem-utils';
 import assert from 'node:assert';
-import puppeteer from 'puppeteer';
+import { launch } from 'puppeteer';
 import type { Page } from 'puppeteer';
 
 const TEST_CASES: readonly [string, (page: Page) => Promise<Omit<TestCaseResult, 'testCaseId'>>][] = [
@@ -68,7 +68,7 @@ const args = parseArgs(process.argv);
 if (!args.cwd) throw new Error('cwd argument required');
 await using server = startHttpServer(args.cwd);
 
-const browser = await puppeteer.launch({
+const browser = await launch({
   args: process.env.CI || process.env.WB_DOCKER === '1' ? ['--no-sandbox', '--disable-setuid-sandbox'] : [],
 });
 const page = await browser.newPage();


### PR DESCRIPTION
## Summary

- Applied the current `wbfy` workflow to this repository.
- Updated the weather example judge to import Puppeteer's `launch` named export directly.
- Confirmed the generator now completes with zero lint warnings.

## Why

- `wbfy` surfaced an `import(no-named-as-default-member)` warning for `puppeteer.launch`.
- Using the named export resolves the warning without changing runtime behavior.

## Testing

- `yarn start /Users/exkazuu/ghq/github.com/WillBooster/exercode-problem-utils` from `~/ghq/github.com/WillBooster/shared/packages/wbfy`
- `yarn verify`
- `yarn check-for-ai` (not available in this package)
