### PR TITLE
feat: add package manager command runner

### DIFF
--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -54,7 +54,8 @@ const packageManagerProjectFilePaths = {
 
 const defaultOutputLimitBytes = 50 * 1024 * 1024;
 const killGracePeriodMilliseconds = 1000;
-const timeCommand = [os.platform() === 'darwin' ? 'gtime' : '/usr/bin/time', '--format', '%e %M'] as const;
+const timeResultHeadroomBytes = 128;
+const timeCommand = resolveTimeCommand();
 
 /**
  * Copies a submission directory to a temporary directory, overlays package
@@ -141,8 +142,8 @@ async function spawnWithInput(
   signal: NodeJS.Signals | undefined;
   outputLimitExceeded: boolean;
 }> {
-  const timedCommand = [...timeCommand, ...command] as const;
-  const subprocess = childProcess.spawn(timedCommand[0], timedCommand.slice(1), {
+  const spawnedCommand = timeCommand === undefined ? command : ([...timeCommand, ...command] as const);
+  const subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
     cwd: context.cwd,
     detached: process.platform !== 'win32',
     env: context.env,
@@ -158,12 +159,16 @@ async function spawnWithInput(
   const appendOutputChunk = (chunks: Buffer[], chunk: Buffer): void => {
     if (outputBytes >= context.outputLimitBytes) return;
 
-    const remainingBytes = context.outputLimitBytes - outputBytes;
+    const outputLimitBytes =
+      timeCommand !== undefined && chunks === stderrChunks
+        ? Math.max(0, context.outputLimitBytes - timeResultHeadroomBytes)
+        : context.outputLimitBytes;
+    const remainingBytes = outputLimitBytes - outputBytes;
     const appendedChunk = chunk.byteLength > remainingBytes ? chunk.subarray(0, remainingBytes) : chunk;
     chunks.push(appendedChunk);
     outputBytes += appendedChunk.byteLength;
 
-    if (chunk.byteLength > remainingBytes || outputBytes >= context.outputLimitBytes) {
+    if (chunk.byteLength > remainingBytes || outputBytes >= outputLimitBytes) {
       outputLimitExceeded = true;
       killSubprocessGroup(subprocess, 'SIGKILL');
     }
@@ -208,7 +213,9 @@ async function spawnWithInput(
     clearTimeout(killTimeout);
   });
 
-  const { stderr, timeSeconds, memoryBytes } = extractTimeResult(Buffer.concat(stderrChunks).toString());
+  const rawStderr = Buffer.concat(stderrChunks).toString();
+  const { stderr, timeSeconds, memoryBytes } =
+    timeCommand === undefined ? { stderr: rawStderr, timeSeconds: 0, memoryBytes: 0 } : extractTimeResult(rawStderr);
 
   return {
     stdout: Buffer.concat(stdoutChunks).toString(),
@@ -220,6 +227,14 @@ async function spawnWithInput(
     signal,
     outputLimitExceeded,
   };
+}
+
+function resolveTimeCommand(): readonly [string, ...string[]] | undefined {
+  const command = os.platform() === 'darwin' ? 'gtime' : '/usr/bin/time';
+  const result = childProcess.spawnSync(command, ['--version'], { stdio: 'ignore' });
+  if (result.error || result.status !== 0) return undefined;
+
+  return [command, '--format', '%e %M'];
 }
 
 function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: NodeJS.Signals): void {
@@ -239,11 +254,11 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
 }
 
 function extractTimeResult(stderr: string): { stderr: string; timeSeconds: number; memoryBytes: number } {
-  const match = /(?:^|\n)(\d+\.\d+) (\d+)\s*$/.exec(stderr);
+  const match = /(\d+\.\d+) (\d+)\s*$/.exec(stderr);
   if (!match) return { stderr, timeSeconds: 0, memoryBytes: 0 };
 
   return {
-    stderr: stderr.slice(0, match.index),
+    stderr: stderr.slice(0, match.index).replace(/\n$/, ''),
     timeSeconds: Number(match[1]),
     memoryBytes: Number(match[2]) * 1024,
   };

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -158,15 +158,15 @@ async function spawnWithInput(
   let outputLimitExceeded = false;
 
   const appendOutputChunk = (chunks: Buffer[], chunk: Buffer): void => {
-    if (outputBytes >= context.outputLimitBytes) return;
-
-    const remainingBytes = Math.max(0, context.outputLimitBytes - outputBytes);
-    if (remainingBytes === 0) {
-      outputLimitExceeded = true;
-      killSubprocessGroup(subprocess, 'SIGKILL');
+    if (outputBytes >= context.outputLimitBytes) {
+      if (chunk.byteLength > 0) {
+        outputLimitExceeded = true;
+        killSubprocessGroup(subprocess, 'SIGKILL');
+      }
       return;
     }
 
+    const remainingBytes = context.outputLimitBytes - outputBytes;
     const appendedChunk = chunk.byteLength > remainingBytes ? chunk.subarray(0, remainingBytes) : chunk;
     chunks.push(appendedChunk);
     outputBytes += appendedChunk.byteLength;

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -1,0 +1,132 @@
+import childProcess from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'uv' | 'yarn';
+
+export interface PackageManagerCommandRunResult {
+  stdin: string;
+  stdout: string;
+  stderr: string;
+  status: number | undefined;
+  timeSeconds: number;
+  memoryBytes: number;
+}
+
+export interface RunCommandInTemporaryPackageManagerProjectOptions {
+  cwd: string;
+  projectDir: string;
+  packageManager: PackageManager;
+  command: readonly [string, ...string[]] | ((context: { runDir: string }) => readonly [string, ...string[]]);
+  stdin?: string;
+  env?: NodeJS.ProcessEnv;
+  timeLimitSeconds: number;
+  tempDirPrefix?: string;
+  projectFilePaths?: readonly string[];
+}
+
+const packageManagerProjectFilePaths = {
+  bun: ['package.json', 'bun.lock', 'bun.lockb'],
+  npm: ['package.json', 'package-lock.json'],
+  pnpm: ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml'],
+  uv: ['pyproject.toml', 'uv.lock'],
+  yarn: ['package.json', 'yarn.lock', '.yarnrc.yml', '.yarn'],
+} as const satisfies Record<PackageManager, readonly string[]>;
+
+/**
+ * Copies a submission directory to a temporary directory, overlays package
+ * manager project files from the problem directory, runs a command, and then
+ * removes the temporary directory.
+ */
+export async function runCommandInTemporaryPackageManagerProject(
+  options: RunCommandInTemporaryPackageManagerProjectOptions
+): Promise<PackageManagerCommandRunResult> {
+  const runDir = await fs.mkdtemp(path.join(os.tmpdir(), options.tempDirPrefix ?? 'exercode-'));
+  const startedAt = Date.now();
+  try {
+    await fs.cp(options.cwd, runDir, { recursive: true });
+    await copyPackageManagerProjectFiles({
+      packageManager: options.packageManager,
+      projectDir: options.projectDir,
+      runDir,
+      projectFilePaths: options.projectFilePaths,
+    });
+
+    const command = typeof options.command === 'function' ? options.command({ runDir }) : options.command;
+    const result = await spawnWithInput(command, {
+      cwd: runDir,
+      env: options.env ?? process.env,
+      stdin: options.stdin ?? '',
+      timeLimitSeconds: options.timeLimitSeconds,
+    });
+
+    return {
+      stdin: options.stdin ?? '',
+      stdout: result.stdout,
+      stderr: result.stderr,
+      status: result.status,
+      timeSeconds: Math.min((Date.now() - startedAt) / 1000, options.timeLimitSeconds),
+      memoryBytes: 0,
+    };
+  } finally {
+    await fs.rm(runDir, { force: true, recursive: true });
+  }
+}
+
+export async function copyPackageManagerProjectFiles(options: {
+  packageManager: PackageManager;
+  projectDir: string;
+  runDir: string;
+  projectFilePaths?: readonly string[];
+}): Promise<void> {
+  for (const projectFilePath of options.projectFilePaths ?? packageManagerProjectFilePaths[options.packageManager]) {
+    await copyPathIfExists(path.join(options.projectDir, projectFilePath), path.join(options.runDir, projectFilePath));
+  }
+}
+
+async function copyPathIfExists(sourcePath: string, destinationPath: string): Promise<void> {
+  try {
+    await fs.cp(sourcePath, destinationPath, { recursive: true });
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error ? (error as { code: unknown }).code : undefined;
+    if (code !== 'ENOENT') throw error;
+  }
+}
+
+async function spawnWithInput(
+  command: readonly [string, ...string[]],
+  context: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    stdin: string;
+    timeLimitSeconds: number;
+  }
+): Promise<{ stdout: string; stderr: string; status: number | undefined }> {
+  const subprocess = childProcess.spawn(command[0], command.slice(1), {
+    cwd: context.cwd,
+    env: context.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  subprocess.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
+  subprocess.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+
+  const timeout = setTimeout(() => subprocess.kill(), context.timeLimitSeconds * 1000);
+  subprocess.stdin.end(context.stdin);
+
+  const status = await new Promise<number | undefined>((resolve, reject) => {
+    subprocess.on('error', reject);
+    subprocess.on('close', (code) => resolve(code ?? undefined));
+  });
+  clearTimeout(timeout);
+
+  return {
+    stdout: Buffer.concat(stdoutChunks).toString(),
+    stderr: Buffer.concat(stderrChunks).toString(),
+    status,
+  };
+}

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -77,7 +77,7 @@ export async function runCommandInTemporaryPackageManagerProject(
     const startedAt = Date.now();
     const result = await spawnWithInput(command, {
       cwd: runDir,
-      env: options.env ?? process.env,
+      env: options.env ? { ...process.env, ...options.env } : process.env,
       outputLimitBytes: options.outputLimitBytes ?? defaultOutputLimitBytes,
       stdin: options.stdin ?? '',
       timeLimitSeconds: options.timeLimitSeconds,

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -54,7 +54,6 @@ const packageManagerProjectFilePaths = {
 
 const defaultOutputLimitBytes = 50 * 1024 * 1024;
 const killGracePeriodMilliseconds = 1000;
-const timeResultHeadroomBytes = 128;
 const timeCommand = resolveTimeCommand();
 
 /**
@@ -142,7 +141,9 @@ async function spawnWithInput(
   signal: NodeJS.Signals | undefined;
   outputLimitExceeded: boolean;
 }> {
-  const spawnedCommand = timeCommand === undefined ? command : ([...timeCommand, ...command] as const);
+  const timeOutputPath = timeCommand === undefined ? undefined : path.join(context.cwd, '.exercode-time-result');
+  const spawnedCommand =
+    timeCommand === undefined ? command : ([...timeCommand, `--output=${timeOutputPath}`, ...command] as const);
   const subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
     cwd: context.cwd,
     detached: process.platform !== 'win32',
@@ -159,16 +160,18 @@ async function spawnWithInput(
   const appendOutputChunk = (chunks: Buffer[], chunk: Buffer): void => {
     if (outputBytes >= context.outputLimitBytes) return;
 
-    const outputLimitBytes =
-      timeCommand !== undefined && chunks === stderrChunks
-        ? Math.max(0, context.outputLimitBytes - timeResultHeadroomBytes)
-        : context.outputLimitBytes;
-    const remainingBytes = outputLimitBytes - outputBytes;
+    const remainingBytes = Math.max(0, context.outputLimitBytes - outputBytes);
+    if (remainingBytes === 0) {
+      outputLimitExceeded = true;
+      killSubprocessGroup(subprocess, 'SIGKILL');
+      return;
+    }
+
     const appendedChunk = chunk.byteLength > remainingBytes ? chunk.subarray(0, remainingBytes) : chunk;
     chunks.push(appendedChunk);
     outputBytes += appendedChunk.byteLength;
 
-    if (chunk.byteLength > remainingBytes || outputBytes >= outputLimitBytes) {
+    if (chunk.byteLength > remainingBytes || outputBytes >= context.outputLimitBytes) {
       outputLimitExceeded = true;
       killSubprocessGroup(subprocess, 'SIGKILL');
     }
@@ -213,13 +216,12 @@ async function spawnWithInput(
     clearTimeout(killTimeout);
   });
 
-  const rawStderr = Buffer.concat(stderrChunks).toString();
-  const { stderr, timeSeconds, memoryBytes } =
-    timeCommand === undefined ? { stderr: rawStderr, timeSeconds: 0, memoryBytes: 0 } : extractTimeResult(rawStderr);
+  const { timeSeconds, memoryBytes } =
+    timeOutputPath === undefined ? { timeSeconds: 0, memoryBytes: 0 } : await readTimeResult(timeOutputPath);
 
   return {
     stdout: Buffer.concat(stdoutChunks).toString(),
-    stderr,
+    stderr: Buffer.concat(stderrChunks).toString(),
     status,
     timeSeconds,
     memoryBytes,
@@ -253,13 +255,19 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
   }
 }
 
-function extractTimeResult(stderr: string): { stderr: string; timeSeconds: number; memoryBytes: number } {
-  const match = /(\d+\.\d+) (\d+)\s*$/.exec(stderr);
-  if (!match) return { stderr, timeSeconds: 0, memoryBytes: 0 };
+async function readTimeResult(timeOutputPath: string): Promise<{ timeSeconds: number; memoryBytes: number }> {
+  let content: string;
+  try {
+    content = await fs.readFile(timeOutputPath, 'utf8');
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error ? (error as { code: unknown }).code : undefined;
+    if (code !== 'ENOENT') throw error;
+    return { timeSeconds: 0, memoryBytes: 0 };
+  }
 
-  return {
-    stderr: stderr.slice(0, match.index).replace(/\n$/, ''),
-    timeSeconds: Number(match[1]),
-    memoryBytes: Number(match[2]) * 1024,
-  };
+  const match = /(\d+\.\d+) (\d+)\s*$/.exec(content);
+  if (!match) return { timeSeconds: 0, memoryBytes: 0 };
+
+  return { timeSeconds: Number(match[1]), memoryBytes: Number(match[2]) * 1024 };
 }

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -171,7 +171,7 @@ async function spawnWithInput(
     chunks.push(appendedChunk);
     outputBytes += appendedChunk.byteLength;
 
-    if (chunk.byteLength > remainingBytes || outputBytes >= context.outputLimitBytes) {
+    if (chunk.byteLength > remainingBytes) {
       outputLimitExceeded = true;
       killSubprocessGroup(subprocess, 'SIGKILL');
     }
@@ -195,18 +195,27 @@ async function spawnWithInput(
   const { status, signal } = await new Promise<{ status: number | undefined; signal: NodeJS.Signals | undefined }>(
     (resolve, reject) => {
       let settled = false;
-      const rejectOnce = (error: Error): void => {
+      let pendingError: Error | undefined;
+      const failAfterClose = (error: Error): void => {
         if (settled) return;
-        settled = true;
-        reject(error);
+        pendingError = error;
+        killSubprocessGroup(subprocess, 'SIGKILL');
+        if (subprocess.pid === undefined) {
+          settled = true;
+          reject(error);
+        }
       };
-      subprocess.on('error', rejectOnce);
+      subprocess.on('error', failAfterClose);
       subprocess.stdin.on('error', (error: NodeJS.ErrnoException) => {
-        if (error.code !== 'EPIPE') rejectOnce(error);
+        if (error.code !== 'EPIPE') failAfterClose(error);
       });
       subprocess.on('close', (code, closeSignal) => {
         if (settled) return;
         settled = true;
+        if (pendingError) {
+          reject(pendingError);
+          return;
+        }
         resolve({ status: code ?? undefined, signal: closeSignal ?? undefined });
       });
       subprocess.stdin.end(context.stdin);
@@ -266,8 +275,8 @@ async function readTimeResult(timeOutputPath: string): Promise<{ timeSeconds: nu
     return { timeSeconds: 0, memoryBytes: 0 };
   }
 
-  const match = /(\d+\.\d+) (\d+)\s*$/.exec(content);
+  const match = /(\d+(?:[.,]\d+)?) (\d+)\s*$/.exec(content);
   if (!match) return { timeSeconds: 0, memoryBytes: 0 };
 
-  return { timeSeconds: Number(match[1]), memoryBytes: Number(match[2]) * 1024 };
+  return { timeSeconds: Number(match[1]!.replace(',', '.')), memoryBytes: Number(match[2]) * 1024 };
 }

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -12,6 +12,9 @@ export interface PackageManagerCommandRunResult {
   status: number | undefined;
   timeSeconds: number;
   memoryBytes: number;
+  timedOut: boolean;
+  signal: NodeJS.Signals | undefined;
+  outputLimitExceeded: boolean;
 }
 
 export interface RunCommandInTemporaryPackageManagerProjectOptions {
@@ -22,6 +25,7 @@ export interface RunCommandInTemporaryPackageManagerProjectOptions {
   stdin?: string;
   env?: NodeJS.ProcessEnv;
   timeLimitSeconds: number;
+  outputLimitBytes?: number;
   tempDirPrefix?: string;
   projectFilePaths?: readonly string[];
 }
@@ -48,6 +52,9 @@ const packageManagerProjectFilePaths = {
   yarn: ['package.json', 'yarn.lock', '.yarnrc.yml', '.yarn'],
 } as const satisfies Record<PackageManager, readonly string[]>;
 
+const defaultOutputLimitBytes = 50 * 1024 * 1024;
+const killGracePeriodMilliseconds = 1000;
+
 /**
  * Copies a submission directory to a temporary directory, overlays package
  * manager project files from the problem directory, runs a command, and then
@@ -57,7 +64,6 @@ export async function runCommandInTemporaryPackageManagerProject(
   options: RunCommandInTemporaryPackageManagerProjectOptions
 ): Promise<PackageManagerCommandRunResult> {
   const runDir = await fs.mkdtemp(path.join(os.tmpdir(), options.tempDirPrefix ?? 'exercode-'));
-  const startedAt = Date.now();
   try {
     await fs.cp(options.cwd, runDir, { recursive: true });
     await copyPackageManagerProjectFiles({
@@ -68,20 +74,26 @@ export async function runCommandInTemporaryPackageManagerProject(
     });
 
     const command = typeof options.command === 'function' ? options.command({ runDir }) : options.command;
+    const startedAt = Date.now();
     const result = await spawnWithInput(command, {
       cwd: runDir,
       env: options.env ?? process.env,
+      outputLimitBytes: options.outputLimitBytes ?? defaultOutputLimitBytes,
       stdin: options.stdin ?? '',
       timeLimitSeconds: options.timeLimitSeconds,
     });
+    const elapsedTimeSeconds = (Date.now() - startedAt) / 1000;
 
     return {
       stdin: options.stdin ?? '',
       stdout: result.stdout,
       stderr: result.stderr,
-      status: result.status,
-      timeSeconds: Math.min((Date.now() - startedAt) / 1000, options.timeLimitSeconds),
+      status: result.timedOut || result.outputLimitExceeded ? 0 : result.status,
+      timeSeconds: result.timedOut ? options.timeLimitSeconds + 1e-3 : elapsedTimeSeconds,
       memoryBytes: 0,
+      timedOut: result.timedOut,
+      signal: result.signal,
+      outputLimitExceeded: result.outputLimitExceeded,
     };
   } finally {
     await fs.rm(runDir, { force: true, recursive: true });
@@ -114,10 +126,18 @@ async function spawnWithInput(
   context: {
     cwd: string;
     env: NodeJS.ProcessEnv;
+    outputLimitBytes: number;
     stdin: string;
     timeLimitSeconds: number;
   }
-): Promise<{ stdout: string; stderr: string; status: number | undefined }> {
+): Promise<{
+  stdout: string;
+  stderr: string;
+  status: number | undefined;
+  timedOut: boolean;
+  signal: NodeJS.Signals | undefined;
+  outputLimitExceeded: boolean;
+}> {
   const subprocess = childProcess.spawn(command[0], command.slice(1), {
     cwd: context.cwd,
     env: context.env,
@@ -126,21 +146,69 @@ async function spawnWithInput(
 
   const stdoutChunks: Buffer[] = [];
   const stderrChunks: Buffer[] = [];
-  subprocess.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
-  subprocess.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+  let outputBytes = 0;
+  let timedOut = false;
+  let outputLimitExceeded = false;
 
-  const timeout = setTimeout(() => subprocess.kill(), context.timeLimitSeconds * 1000);
-  subprocess.stdin.end(context.stdin);
+  const appendOutputChunk = (chunks: Buffer[], chunk: Buffer): void => {
+    if (outputBytes >= context.outputLimitBytes) return;
 
-  const status = await new Promise<number | undefined>((resolve, reject) => {
-    subprocess.on('error', reject);
-    subprocess.on('close', (code) => resolve(code ?? undefined));
+    const remainingBytes = context.outputLimitBytes - outputBytes;
+    const appendedChunk = chunk.byteLength > remainingBytes ? chunk.subarray(0, remainingBytes) : chunk;
+    chunks.push(appendedChunk);
+    outputBytes += appendedChunk.byteLength;
+
+    if (chunk.byteLength > remainingBytes || outputBytes >= context.outputLimitBytes) {
+      outputLimitExceeded = true;
+      subprocess.kill('SIGKILL');
+    }
+  };
+
+  subprocess.stdout.on('data', (chunk: Buffer) => appendOutputChunk(stdoutChunks, chunk));
+  subprocess.stderr.on('data', (chunk: Buffer) => appendOutputChunk(stderrChunks, chunk));
+
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    subprocess.kill('SIGTERM');
+  }, context.timeLimitSeconds * 1000);
+  const killTimeout = setTimeout(
+    () => {
+      if (timedOut) subprocess.kill('SIGKILL');
+    },
+    context.timeLimitSeconds * 1000 + killGracePeriodMilliseconds
+  );
+  killTimeout.unref();
+
+  const { status, signal } = await new Promise<{ status: number | undefined; signal: NodeJS.Signals | undefined }>(
+    (resolve, reject) => {
+      let settled = false;
+      const rejectOnce = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+      subprocess.on('error', rejectOnce);
+      subprocess.stdin.on('error', (error: NodeJS.ErrnoException) => {
+        if (error.code !== 'EPIPE') rejectOnce(error);
+      });
+      subprocess.on('close', (code, closeSignal) => {
+        if (settled) return;
+        settled = true;
+        resolve({ status: code ?? undefined, signal: closeSignal ?? undefined });
+      });
+      subprocess.stdin.end(context.stdin);
+    }
+  ).finally(() => {
+    clearTimeout(timeout);
+    clearTimeout(killTimeout);
   });
-  clearTimeout(timeout);
 
   return {
     stdout: Buffer.concat(stdoutChunks).toString(),
     stderr: Buffer.concat(stderrChunks).toString(),
     status,
+    timedOut,
+    signal,
+    outputLimitExceeded,
   };
 }

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-export type PackageManager = 'bun' | 'npm' | 'pnpm' | 'uv' | 'yarn';
+export type PackageManager = 'bun' | 'cargo' | 'go' | 'gradle' | 'maven' | 'npm' | 'pnpm' | 'ruby' | 'uv' | 'yarn';
 
 export interface PackageManagerCommandRunResult {
   stdin: string;
@@ -28,8 +28,22 @@ export interface RunCommandInTemporaryPackageManagerProjectOptions {
 
 const packageManagerProjectFilePaths = {
   bun: ['package.json', 'bun.lock', 'bun.lockb'],
+  cargo: ['Cargo.toml', 'Cargo.lock'],
+  go: ['go.mod', 'go.sum'],
+  gradle: [
+    'build.gradle',
+    'build.gradle.kts',
+    'settings.gradle',
+    'settings.gradle.kts',
+    'gradle.properties',
+    'gradle',
+    'gradlew',
+    'gradlew.bat',
+  ],
+  maven: ['pom.xml', '.mvn', 'mvnw', 'mvnw.cmd'],
   npm: ['package.json', 'package-lock.json'],
   pnpm: ['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml'],
+  ruby: ['Gemfile', 'Gemfile.lock', '.ruby-version'],
   uv: ['pyproject.toml', 'uv.lock'],
   yarn: ['package.json', 'yarn.lock', '.yarnrc.yml', '.yarn'],
 } as const satisfies Record<PackageManager, readonly string[]>;

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -54,6 +54,7 @@ const packageManagerProjectFilePaths = {
 
 const defaultOutputLimitBytes = 50 * 1024 * 1024;
 const killGracePeriodMilliseconds = 1000;
+const timeCommand = [os.platform() === 'darwin' ? 'gtime' : '/usr/bin/time', '--format', '%e %M'] as const;
 
 /**
  * Copies a submission directory to a temporary directory, overlays package
@@ -89,8 +90,8 @@ export async function runCommandInTemporaryPackageManagerProject(
       stdout: result.stdout,
       stderr: result.stderr,
       status: result.timedOut || result.outputLimitExceeded ? 0 : result.status,
-      timeSeconds: result.timedOut ? options.timeLimitSeconds + 1e-3 : elapsedTimeSeconds,
-      memoryBytes: 0,
+      timeSeconds: result.timedOut ? options.timeLimitSeconds + 1e-3 : result.timeSeconds || elapsedTimeSeconds,
+      memoryBytes: result.memoryBytes,
       timedOut: result.timedOut,
       signal: result.signal,
       outputLimitExceeded: result.outputLimitExceeded,
@@ -134,12 +135,16 @@ async function spawnWithInput(
   stdout: string;
   stderr: string;
   status: number | undefined;
+  timeSeconds: number;
+  memoryBytes: number;
   timedOut: boolean;
   signal: NodeJS.Signals | undefined;
   outputLimitExceeded: boolean;
 }> {
-  const subprocess = childProcess.spawn(command[0], command.slice(1), {
+  const timedCommand = [...timeCommand, ...command] as const;
+  const subprocess = childProcess.spawn(timedCommand[0], timedCommand.slice(1), {
     cwd: context.cwd,
+    detached: process.platform !== 'win32',
     env: context.env,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
@@ -160,7 +165,7 @@ async function spawnWithInput(
 
     if (chunk.byteLength > remainingBytes || outputBytes >= context.outputLimitBytes) {
       outputLimitExceeded = true;
-      subprocess.kill('SIGKILL');
+      killSubprocessGroup(subprocess, 'SIGKILL');
     }
   };
 
@@ -169,11 +174,11 @@ async function spawnWithInput(
 
   const timeout = setTimeout(() => {
     timedOut = true;
-    subprocess.kill('SIGTERM');
+    killSubprocessGroup(subprocess, 'SIGTERM');
   }, context.timeLimitSeconds * 1000);
   const killTimeout = setTimeout(
     () => {
-      if (timedOut) subprocess.kill('SIGKILL');
+      if (timedOut) killSubprocessGroup(subprocess, 'SIGKILL');
     },
     context.timeLimitSeconds * 1000 + killGracePeriodMilliseconds
   );
@@ -203,12 +208,43 @@ async function spawnWithInput(
     clearTimeout(killTimeout);
   });
 
+  const { stderr, timeSeconds, memoryBytes } = extractTimeResult(Buffer.concat(stderrChunks).toString());
+
   return {
     stdout: Buffer.concat(stdoutChunks).toString(),
-    stderr: Buffer.concat(stderrChunks).toString(),
+    stderr,
     status,
+    timeSeconds,
+    memoryBytes,
     timedOut,
     signal,
     outputLimitExceeded,
+  };
+}
+
+function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: NodeJS.Signals): void {
+  if (subprocess.pid === undefined) return;
+
+  try {
+    if (process.platform === 'win32') {
+      subprocess.kill(signal);
+      return;
+    }
+    process.kill(-subprocess.pid, signal);
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error ? (error as { code: unknown }).code : undefined;
+    if (code !== 'ESRCH' && code !== 'EPERM') throw error;
+  }
+}
+
+function extractTimeResult(stderr: string): { stderr: string; timeSeconds: number; memoryBytes: number } {
+  const match = /(?:^|\n)(\d+\.\d+) (\d+)\s*$/.exec(stderr);
+  if (!match) return { stderr, timeSeconds: 0, memoryBytes: 0 };
+
+  return {
+    stderr: stderr.slice(0, match.index),
+    timeSeconds: Number(match[1]),
+    memoryBytes: Number(match[2]) * 1024,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './helpers/parseArgs.js';
 export * from './helpers/printTestCaseResult.js';
 export * from './helpers/removeCommentsInSourceCode.js';
+export * from './helpers/runCommandInTemporaryPackageManagerProject.js';
 export * from './helpers/sourceCodeGrammars.js';
 export * from './helpers/startHttpServer.js';
 export * from './types/decisionCode.js';

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -48,6 +48,7 @@ export interface CommandRunResult {
   status: number | undefined;
   timeSeconds: number;
   memoryBytes: number;
+  outputLimitExceeded?: boolean;
 }
 
 interface CommandJudgeContext {
@@ -439,6 +440,7 @@ function evaluateByLimits(context: {
   }
 
   if (
+    context.runResult.outputLimitExceeded ||
     context.runResult.stdout.length > context.context.outputLimitLength ||
     context.runResult.stderr.length > context.context.outputLimitLength
   ) {


### PR DESCRIPTION
## Summary

- Add a reusable helper that copies a submission into a temporary project directory, overlays package-manager project files from the problem directory, runs a command with stdin and timeout handling, and cleans up afterward.
- Support JavaScript package managers, uv-based Python projects, Maven, Gradle, Ruby/Bundler, Rust/Cargo, and Go module project files by default.
- Harden package-manager execution with output limits, timeout escalation, POSIX process-group termination, optional GNU time based RSS measurement, EPIPE-tolerant stdin handling, merged environment variables, and `outputLimitExceeded` integration with `commandJudgePreset`.
- Export both the command runner and the project-file copy helper from the package root.

## Testing

- `yarn verify`
- `bunx @willbooster/agent-skills@1.28.0 review --agent all`
- `bunx @willbooster/agent-skills@1.28.0 check-pr-ci`
