### PR TITLE
feat: add uv python project runner

### DIFF
--- a/src/helpers/runPythonInTemporaryUvProject.ts
+++ b/src/helpers/runPythonInTemporaryUvProject.ts
@@ -21,17 +21,10 @@ const defaultPythonArgs = ['main.py'] as const;
 export function runPythonInTemporaryUvProject(
   options: RunPythonInTemporaryUvProjectOptions
 ): Promise<PackageManagerCommandRunResult> {
+  const { pythonArgs = defaultPythonArgs, uvArgs = [], ...restOptions } = options;
   return runCommandInTemporaryPackageManagerProject({
-    ...options,
+    ...restOptions,
     packageManager: 'uv',
-    command: [
-      'uv',
-      'run',
-      '--quiet',
-      '--no-progress',
-      ...(options.uvArgs ?? []),
-      'python',
-      ...(options.pythonArgs ?? defaultPythonArgs),
-    ] as const,
+    command: ['uv', 'run', '--quiet', '--no-progress', ...uvArgs, 'python', ...pythonArgs] as const,
   });
 }

--- a/src/helpers/runPythonInTemporaryUvProject.ts
+++ b/src/helpers/runPythonInTemporaryUvProject.ts
@@ -24,10 +24,14 @@ export function runPythonInTemporaryUvProject(
   return runCommandInTemporaryPackageManagerProject({
     ...options,
     packageManager: 'uv',
-    command: ['uv', 'run', '--quiet', '--no-progress', ...(options.uvArgs ?? []), 'python', ...pythonArgs(options)],
+    command: [
+      'uv',
+      'run',
+      '--quiet',
+      '--no-progress',
+      ...(options.uvArgs ?? []),
+      'python',
+      ...(options.pythonArgs ?? defaultPythonArgs),
+    ] as const,
   });
-}
-
-function pythonArgs(options: RunPythonInTemporaryUvProjectOptions): readonly [string, ...string[]] {
-  return options.pythonArgs ?? defaultPythonArgs;
 }

--- a/src/helpers/runPythonInTemporaryUvProject.ts
+++ b/src/helpers/runPythonInTemporaryUvProject.ts
@@ -1,0 +1,33 @@
+import {
+  type PackageManagerCommandRunResult,
+  runCommandInTemporaryPackageManagerProject,
+  type RunCommandInTemporaryPackageManagerProjectOptions,
+} from './runCommandInTemporaryPackageManagerProject.js';
+
+export interface RunPythonInTemporaryUvProjectOptions extends Omit<
+  RunCommandInTemporaryPackageManagerProjectOptions,
+  'command' | 'packageManager'
+> {
+  pythonArgs?: readonly [string, ...string[]];
+  uvArgs?: readonly string[];
+}
+
+const defaultPythonArgs = ['main.py'] as const;
+
+/**
+ * Runs a Python command inside a temporary uv project created from a submission
+ * directory and the problem's `pyproject.toml` / `uv.lock`.
+ */
+export function runPythonInTemporaryUvProject(
+  options: RunPythonInTemporaryUvProjectOptions
+): Promise<PackageManagerCommandRunResult> {
+  return runCommandInTemporaryPackageManagerProject({
+    ...options,
+    packageManager: 'uv',
+    command: ['uv', 'run', '--quiet', '--no-progress', ...(options.uvArgs ?? []), 'python', ...pythonArgs(options)],
+  });
+}
+
+function pythonArgs(options: RunPythonInTemporaryUvProjectOptions): readonly [string, ...string[]] {
+  return options.pythonArgs ?? defaultPythonArgs;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export * from './helpers/parseArgs.js';
 export * from './helpers/printTestCaseResult.js';
 export * from './helpers/removeCommentsInSourceCode.js';
 export * from './helpers/runCommandInTemporaryPackageManagerProject.js';
+export * from './helpers/runPythonInTemporaryUvProject.js';
 export * from './helpers/sourceCodeGrammars.js';
 export * from './helpers/startHttpServer.js';
 export * from './types/decisionCode.js';


### PR DESCRIPTION
## Summary

- Add `runPythonInTemporaryUvProject` as a thin helper over `runCommandInTemporaryPackageManagerProject`.
- Default to `uv run --quiet --no-progress python main.py` inside the temporary uv project directory.
- Preserve existing project-file behavior, so `pyproject.toml` and `uv.lock` are copied from the problem directory and used by uv.
- Keep helper-only options (`pythonArgs`, `uvArgs`) out of the lower-level runner options.

## Why

- Python/uv judges currently repeat the same `packageManager: "uv"` and command-array boilerplate.
- This helper keeps the existing temporary-project behavior while making judge code shorter and less error-prone.

## Testing

- `yarn verify`
