### PR TITLE
feat: check problem isolation in command debug mode

### DIFF
--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -120,7 +120,6 @@ async function symlinkAllAncestorNodeModules(tempRoot: string, problemDir: strin
     if (fs.existsSync(nodeModulesPath)) {
       const targetSymlinkPath = path.join(tempRoot, toTempRelativePath(currentDir), 'node_modules');
       try {
-        await fs.promises.mkdir(path.dirname(targetSymlinkPath), { recursive: true });
         await fs.promises.symlink(
           nodeModulesPath,
           targetSymlinkPath,

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -41,17 +41,15 @@ export async function checkProblemDirIsolation(
       ]);
       return { passed: true };
     }
+    const env = createIsolationEnv(problemDir);
+    const execArgv = process.execArgv.filter((arg) => !arg.startsWith('--inspect'));
     const paramsJson = JSON.stringify(params);
-    const spawnResult = child_process.spawnSync(
-      process.execPath,
-      [...process.execArgv, scriptPath, copiedCwd, paramsJson],
-      {
-        cwd: copiedProblemDir,
-        encoding: 'utf8',
-        env: process.env,
-        timeout: ISOLATION_CHECK_TIMEOUT_MS,
-      }
-    );
+    const spawnResult = child_process.spawnSync(process.execPath, [...execArgv, scriptPath, copiedCwd, paramsJson], {
+      cwd: copiedProblemDir,
+      encoding: 'utf8',
+      env,
+      timeout: ISOLATION_CHECK_TIMEOUT_MS,
+    });
     const stdout = spawnResult.stdout ?? '';
     const stderr = spawnResult.stderr ?? '';
 
@@ -101,11 +99,34 @@ export async function checkProblemDirIsolation(
   }
 }
 
+function createIsolationEnv(problemDir: string): NodeJS.ProcessEnv {
+  const nodeModulesPaths = findAncestorNodeModulesPaths(problemDir);
+  if (nodeModulesPaths.length === 0) return process.env;
+
+  return {
+    ...process.env,
+    NODE_PATH: [...nodeModulesPaths, ...(process.env.NODE_PATH ? [process.env.NODE_PATH] : [])].join(path.delimiter),
+  };
+}
+
+function findAncestorNodeModulesPaths(problemDir: string): string[] {
+  const nodeModulesPaths: string[] = [];
+  let currentDir = path.resolve(problemDir);
+  while (true) {
+    const nodeModulesPath = path.join(currentDir, 'node_modules');
+    if (fs.existsSync(nodeModulesPath)) nodeModulesPaths.push(nodeModulesPath);
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) return nodeModulesPaths;
+    currentDir = parentDir;
+  }
+}
+
 function getInvokedScriptPath(problemDir: string): string {
   const scriptPath = process.argv[1];
-  if (!scriptPath) return './judge.ts';
+  if (!scriptPath) return `.${path.sep}judge.ts`;
   const relativeScriptPath = path.relative(problemDir, path.resolve(scriptPath));
-  return relativeScriptPath.startsWith('.') ? relativeScriptPath : `./${relativeScriptPath}`;
+  return relativeScriptPath.startsWith('.') ? relativeScriptPath : `.${path.sep}${relativeScriptPath}`;
 }
 
 function isAcceptedJudgeOutput(stdout: string): boolean {

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -1,0 +1,70 @@
+import child_process from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { printDebugBanner } from './printDebugBanner.js';
+import type { ResolvedCwd } from './resolveCwds.js';
+
+export interface ProblemDirIsolationCheckResult {
+  passed: boolean;
+}
+
+/**
+ * Check that a judge can run after only the problem directory is copied elsewhere.
+ */
+export async function checkProblemDirIsolation(
+  problemDir: string,
+  resolvedCwd: ResolvedCwd,
+  params: unknown
+): Promise<ProblemDirIsolationCheckResult> {
+  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'problem-utils-isolation_'));
+  const copiedProblemDir = path.join(tempRoot, path.basename(problemDir));
+  try {
+    await fs.promises.cp(problemDir, copiedProblemDir, { recursive: true });
+
+    const relativeCwd = path.relative(problemDir, resolvedCwd.cwd);
+    const copiedCwd = path.join(copiedProblemDir, relativeCwd);
+    const scriptName = getInvokedScriptName();
+    const spawnResult = child_process.spawnSync('bun', ['run', scriptName, copiedCwd, JSON.stringify(params)], {
+      cwd: copiedProblemDir,
+      encoding: 'utf8',
+      env: process.env,
+    });
+
+    if (spawnResult.status === 0) {
+      printDebugBanner([
+        '[DEBUG MODE] isolated problem directory check passed',
+        '',
+        `Copied problem dir : ${copiedProblemDir}`,
+        `Checked cwd        : ${relativeCwd}`,
+      ]);
+      return { passed: true };
+    }
+
+    printDebugBanner([
+      '[DEBUG MODE] isolated problem directory check failed',
+      '',
+      'The judge did not run after copying only the problem directory to a temporary location.',
+      'Make sure judge.ts imports only files included in the problem directory.',
+      '',
+      `Copied problem dir : ${copiedProblemDir}`,
+      `Checked cwd        : ${relativeCwd}`,
+      `Exit status        : ${spawnResult.status ?? 'signal'}`,
+      '',
+      'stdout:',
+      spawnResult.stdout.trimEnd() || '<empty>',
+      '',
+      'stderr:',
+      spawnResult.stderr.trimEnd() || '<empty>',
+    ]);
+    return { passed: false };
+  } finally {
+    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function getInvokedScriptName(): string {
+  const scriptPath = process.argv[1];
+  return scriptPath ? path.basename(scriptPath) : 'judge.ts';
+}

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -29,7 +29,8 @@ export async function checkProblemDirIsolation(
     const relativeCwd = path.relative(problemDir, resolvedCwd.cwd);
     const copiedCwd = path.join(copiedProblemDir, relativeCwd);
     const scriptName = getInvokedScriptName();
-    const spawnResult = child_process.spawnSync('bun', ['run', scriptName, copiedCwd, JSON.stringify(params)], {
+    const paramsJson = JSON.stringify(params) ?? '{}';
+    const spawnResult = child_process.spawnSync('bun', ['run', scriptName, copiedCwd, paramsJson], {
       cwd: copiedProblemDir,
       encoding: 'utf8',
       env: process.env,

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -28,6 +28,7 @@ export async function checkProblemDirIsolation(
     tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'problem-utils-isolation_'));
     const copiedProblemDir = path.join(tempRoot, path.basename(problemDir));
     await fs.promises.cp(problemDir, copiedProblemDir, { recursive: true });
+    await symlinkAncestorNodeModules(tempRoot, problemDir);
 
     const relativeCwd = path.relative(problemDir, resolvedCwd.cwd);
     const copiedCwd = path.join(copiedProblemDir, relativeCwd);
@@ -41,13 +42,12 @@ export async function checkProblemDirIsolation(
       ]);
       return { passed: true };
     }
-    const env = createIsolationEnv(problemDir);
     const execArgv = process.execArgv.filter((arg) => !arg.startsWith('--inspect'));
     const paramsJson = JSON.stringify(params);
     const spawnResult = child_process.spawnSync(process.execPath, [...execArgv, scriptPath, copiedCwd, paramsJson], {
       cwd: copiedProblemDir,
       encoding: 'utf8',
-      env,
+      env: process.env,
       timeout: ISOLATION_CHECK_TIMEOUT_MS,
     });
     const stdout = spawnResult.stdout ?? '';
@@ -99,25 +99,29 @@ export async function checkProblemDirIsolation(
   }
 }
 
-function createIsolationEnv(problemDir: string): NodeJS.ProcessEnv {
-  const nodeModulesPaths = findAncestorNodeModulesPaths(problemDir);
-  if (nodeModulesPaths.length === 0) return process.env;
+async function symlinkAncestorNodeModules(tempRoot: string, problemDir: string): Promise<void> {
+  const ancestorNodeModulesPath = findAncestorNodeModulesPath(problemDir);
+  if (!ancestorNodeModulesPath) return;
 
-  return {
-    ...process.env,
-    NODE_PATH: [...nodeModulesPaths, ...(process.env.NODE_PATH ? [process.env.NODE_PATH] : [])].join(path.delimiter),
-  };
+  try {
+    await fs.promises.symlink(
+      ancestorNodeModulesPath,
+      path.join(tempRoot, 'node_modules'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    );
+  } catch {
+    // Package resolution is best-effort; the isolation check still reports a clear spawn failure if imports break.
+  }
 }
 
-function findAncestorNodeModulesPaths(problemDir: string): string[] {
-  const nodeModulesPaths: string[] = [];
+function findAncestorNodeModulesPath(problemDir: string): string | undefined {
   let currentDir = path.resolve(problemDir);
   while (true) {
     const nodeModulesPath = path.join(currentDir, 'node_modules');
-    if (fs.existsSync(nodeModulesPath)) nodeModulesPaths.push(nodeModulesPath);
+    if (fs.existsSync(nodeModulesPath)) return nodeModulesPath;
 
     const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir) return nodeModulesPaths;
+    if (parentDir === currentDir) return undefined;
     currentDir = parentDir;
   }
 }

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -21,16 +21,17 @@ export async function checkProblemDirIsolation(
   resolvedCwd: ResolvedCwd,
   params: unknown
 ): Promise<ProblemDirIsolationCheckResult> {
-  const tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'problem-utils-isolation_'));
-  const copiedProblemDir = path.join(tempRoot, path.basename(problemDir));
+  let tempRoot: string | undefined;
   try {
+    tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'problem-utils-isolation_'));
+    const copiedProblemDir = path.join(tempRoot, path.basename(problemDir));
     await fs.promises.cp(problemDir, copiedProblemDir, { recursive: true });
 
     const relativeCwd = path.relative(problemDir, resolvedCwd.cwd);
     const copiedCwd = path.join(copiedProblemDir, relativeCwd);
-    const scriptName = getInvokedScriptName();
+    const scriptPath = getInvokedScriptPath(problemDir);
     const paramsJson = JSON.stringify(params) ?? '{}';
-    const spawnResult = child_process.spawnSync('bun', ['run', scriptName, copiedCwd, paramsJson], {
+    const spawnResult = child_process.spawnSync('bun', ['run', scriptPath, copiedCwd, paramsJson], {
       cwd: copiedProblemDir,
       encoding: 'utf8',
       env: process.env,
@@ -66,18 +67,25 @@ export async function checkProblemDirIsolation(
       stderr.trimEnd() || '<empty>',
     ]);
     return { passed: false };
+  } catch (error) {
+    printDebugBanner([
+      '[DEBUG MODE] isolated problem directory check failed due to an unexpected error',
+      '',
+      error instanceof Error ? error.message : String(error),
+    ]);
+    return { passed: false };
   } finally {
-    await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    if (tempRoot) await fs.promises.rm(tempRoot, { recursive: true, force: true });
   }
 }
 
-function getInvokedScriptName(): string {
+function getInvokedScriptPath(problemDir: string): string {
   const scriptPath = process.argv[1];
-  return scriptPath ? path.basename(scriptPath) : 'judge.ts';
+  return scriptPath ? path.relative(problemDir, path.resolve(scriptPath)) : 'judge.ts';
 }
 
 function isAcceptedJudgeOutput(stdout: string): boolean {
-  const resultLines = stdout.split('\n').filter((line) => line.startsWith(TEST_CASE_RESULT_PREFIX));
+  const resultLines = stdout.split(/\r?\n/).filter((line) => line.startsWith(TEST_CASE_RESULT_PREFIX));
   if (resultLines.length === 0) return false;
 
   return resultLines.every((line) => {

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -26,16 +26,17 @@ export async function checkProblemDirIsolation(
   let tempRoot: string | undefined;
   try {
     tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'problem-utils-isolation_'));
-    const copiedProblemDir = path.join(tempRoot, path.basename(problemDir));
-    await fs.promises.cp(problemDir, copiedProblemDir, {
+    const absoluteProblemDir = path.resolve(problemDir);
+    const copiedProblemDir = path.join(tempRoot, path.basename(absoluteProblemDir));
+    await fs.promises.cp(absoluteProblemDir, copiedProblemDir, {
       recursive: true,
       filter: isCopiedProblemPath,
     });
-    await symlinkAncestorNodeModules(tempRoot, problemDir);
+    await symlinkAncestorNodeModules(tempRoot, absoluteProblemDir);
 
-    const relativeCwd = path.relative(problemDir, resolvedCwd.cwd);
+    const relativeCwd = path.relative(absoluteProblemDir, path.resolve(resolvedCwd.cwd));
     const copiedCwd = path.join(copiedProblemDir, relativeCwd);
-    const scriptPath = getInvokedScriptPath(problemDir);
+    const scriptPath = getInvokedScriptPath(absoluteProblemDir);
     if (scriptPath.startsWith('..') || path.isAbsolute(scriptPath)) {
       printDebugBanner([
         '[DEBUG MODE] isolated problem directory check skipped',

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -48,7 +48,7 @@ export async function checkProblemDirIsolation(
       return { passed: true };
     }
     const execArgv = process.execArgv.filter(isIsolationExecArg);
-    const paramsJson = JSON.stringify(params);
+    const paramsJson = JSON.stringify(isJudgeParamsObject(params) ? params : {});
     const spawnResult = child_process.spawnSync(process.execPath, [...execArgv, scriptPath, copiedCwd, paramsJson], {
       cwd: copiedProblemDir,
       encoding: 'utf8',
@@ -111,6 +111,10 @@ function isCopiedProblemPath(src: string): boolean {
 
 function isIsolationExecArg(arg: string): boolean {
   return !arg.startsWith('--inspect') && !arg.startsWith('--watch') && !arg.startsWith('--hot');
+}
+
+function isJudgeParamsObject(params: unknown): params is object {
+  return params !== undefined && params !== null && typeof params === 'object' && !Array.isArray(params);
 }
 
 async function symlinkAllAncestorNodeModules(tempRoot: string, problemDir: string): Promise<void> {

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -29,7 +29,7 @@ export async function checkProblemDirIsolation(
     const copiedProblemDir = path.join(tempRoot, path.basename(problemDir));
     await fs.promises.cp(problemDir, copiedProblemDir, {
       recursive: true,
-      filter: (src) => path.basename(src) !== 'node_modules',
+      filter: isCopiedProblemPath,
     });
     await symlinkAncestorNodeModules(tempRoot, problemDir);
 
@@ -45,7 +45,7 @@ export async function checkProblemDirIsolation(
       ]);
       return { passed: true };
     }
-    const execArgv = process.execArgv.filter((arg) => !arg.startsWith('--inspect'));
+    const execArgv = process.execArgv.filter(isIsolationExecArg);
     const paramsJson = JSON.stringify(params);
     const spawnResult = child_process.spawnSync(process.execPath, [...execArgv, scriptPath, copiedCwd, paramsJson], {
       cwd: copiedProblemDir,
@@ -100,6 +100,15 @@ export async function checkProblemDirIsolation(
       }
     }
   }
+}
+
+function isCopiedProblemPath(src: string): boolean {
+  const name = path.basename(src);
+  return name !== 'node_modules' && name !== '.git';
+}
+
+function isIsolationExecArg(arg: string): boolean {
+  return !arg.startsWith('--inspect') && !arg.startsWith('--watch') && !arg.startsWith('--hot');
 }
 
 async function symlinkAncestorNodeModules(tempRoot: string, problemDir: string): Promise<void> {

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -41,13 +41,17 @@ export async function checkProblemDirIsolation(
       ]);
       return { passed: true };
     }
-    const paramsJson = JSON.stringify(params) ?? '{}';
-    const spawnResult = child_process.spawnSync('bun', ['run', scriptPath, copiedCwd, paramsJson], {
-      cwd: copiedProblemDir,
-      encoding: 'utf8',
-      env: process.env,
-      timeout: ISOLATION_CHECK_TIMEOUT_MS,
-    });
+    const paramsJson = JSON.stringify(params);
+    const spawnResult = child_process.spawnSync(
+      process.execPath,
+      [...process.execArgv, scriptPath, copiedCwd, paramsJson],
+      {
+        cwd: copiedProblemDir,
+        encoding: 'utf8',
+        env: process.env,
+        timeout: ISOLATION_CHECK_TIMEOUT_MS,
+      }
+    );
     const stdout = spawnResult.stdout ?? '';
     const stderr = spawnResult.stderr ?? '';
 

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -27,7 +27,10 @@ export async function checkProblemDirIsolation(
   try {
     tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'problem-utils-isolation_'));
     const copiedProblemDir = path.join(tempRoot, path.basename(problemDir));
-    await fs.promises.cp(problemDir, copiedProblemDir, { recursive: true });
+    await fs.promises.cp(problemDir, copiedProblemDir, {
+      recursive: true,
+      filter: (src) => path.basename(src) !== 'node_modules',
+    });
     await symlinkAncestorNodeModules(tempRoot, problemDir);
 
     const relativeCwd = path.relative(problemDir, resolvedCwd.cwd);
@@ -130,6 +133,7 @@ function getInvokedScriptPath(problemDir: string): string {
   const scriptPath = process.argv[1];
   if (!scriptPath) return `.${path.sep}judge.ts`;
   const relativeScriptPath = path.relative(problemDir, path.resolve(scriptPath));
+  if (path.isAbsolute(relativeScriptPath)) return relativeScriptPath;
   return relativeScriptPath.startsWith('.') ? relativeScriptPath : `.${path.sep}${relativeScriptPath}`;
 }
 

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -57,7 +57,7 @@ export async function checkProblemDirIsolation(
       '',
       `Copied problem dir : ${copiedProblemDir}`,
       `Checked cwd        : ${relativeCwd}`,
-      `Exit status        : ${spawnResult.status ?? 'signal'}`,
+      `Exit status        : ${spawnResult.status ?? spawnResult.signal ?? 'unknown'}`,
       `Spawn error        : ${spawnResult.error?.message ?? '<none>'}`,
       '',
       'stdout:',
@@ -75,13 +75,21 @@ export async function checkProblemDirIsolation(
     ]);
     return { passed: false };
   } finally {
-    if (tempRoot) await fs.promises.rm(tempRoot, { recursive: true, force: true });
+    if (tempRoot) {
+      try {
+        await fs.promises.rm(tempRoot, { recursive: true, force: true });
+      } catch {
+        // Cleanup errors should not mask the primary isolation check result.
+      }
+    }
   }
 }
 
 function getInvokedScriptPath(problemDir: string): string {
   const scriptPath = process.argv[1];
-  return scriptPath ? path.relative(problemDir, path.resolve(scriptPath)) : 'judge.ts';
+  if (!scriptPath) return './judge.ts';
+  const relativeScriptPath = path.relative(problemDir, path.resolve(scriptPath));
+  return relativeScriptPath.startsWith('.') ? relativeScriptPath : `./${relativeScriptPath}`;
 }
 
 function isAcceptedJudgeOutput(stdout: string): boolean {

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -137,7 +137,8 @@ async function symlinkAllAncestorNodeModules(tempRoot: string, problemDir: strin
 }
 
 function toTempRelativePath(absolutePath: string): string {
-  return absolutePath.replace(/^([a-zA-Z]):/, '$1');
+  const { root } = path.parse(absolutePath);
+  return path.relative(root, absolutePath);
 }
 
 function getInvokedScriptPath(problemDir: string): string {

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -3,6 +3,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { DecisionCode } from '../types/decisionCode.js';
+import { TEST_CASE_RESULT_PREFIX, testCaseResultSchema } from '../types/testCaseResult.js';
+
 import { printDebugBanner } from './printDebugBanner.js';
 import type { ResolvedCwd } from './resolveCwds.js';
 
@@ -32,7 +35,7 @@ export async function checkProblemDirIsolation(
       env: process.env,
     });
 
-    if (spawnResult.status === 0) {
+    if (spawnResult.status === 0 && isAcceptedJudgeOutput(spawnResult.stdout)) {
       printDebugBanner([
         '[DEBUG MODE] isolated problem directory check passed',
         '',
@@ -45,7 +48,7 @@ export async function checkProblemDirIsolation(
     printDebugBanner([
       '[DEBUG MODE] isolated problem directory check failed',
       '',
-      'The judge did not run after copying only the problem directory to a temporary location.',
+      'The judge did not complete successfully after copying only the problem directory to a temporary location.',
       'Make sure judge.ts imports only files included in the problem directory.',
       '',
       `Copied problem dir : ${copiedProblemDir}`,
@@ -67,4 +70,18 @@ export async function checkProblemDirIsolation(
 function getInvokedScriptName(): string {
   const scriptPath = process.argv[1];
   return scriptPath ? path.basename(scriptPath) : 'judge.ts';
+}
+
+function isAcceptedJudgeOutput(stdout: string): boolean {
+  const resultLines = stdout.split('\n').filter((line) => line.startsWith(TEST_CASE_RESULT_PREFIX));
+  if (resultLines.length === 0) return false;
+
+  return resultLines.every((line) => {
+    try {
+      const parsedResult = testCaseResultSchema.safeParse(JSON.parse(line.slice(TEST_CASE_RESULT_PREFIX.length)));
+      return parsedResult.success && parsedResult.data.decisionCode === DecisionCode.ACCEPTED;
+    } catch {
+      return false;
+    }
+  });
 }

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -34,8 +34,10 @@ export async function checkProblemDirIsolation(
       encoding: 'utf8',
       env: process.env,
     });
+    const stdout = spawnResult.stdout ?? '';
+    const stderr = spawnResult.stderr ?? '';
 
-    if (spawnResult.status === 0 && isAcceptedJudgeOutput(spawnResult.stdout)) {
+    if (spawnResult.status === 0 && isAcceptedJudgeOutput(stdout)) {
       printDebugBanner([
         '[DEBUG MODE] isolated problem directory check passed',
         '',
@@ -54,12 +56,13 @@ export async function checkProblemDirIsolation(
       `Copied problem dir : ${copiedProblemDir}`,
       `Checked cwd        : ${relativeCwd}`,
       `Exit status        : ${spawnResult.status ?? 'signal'}`,
+      `Spawn error        : ${spawnResult.error?.message ?? '<none>'}`,
       '',
       'stdout:',
-      spawnResult.stdout.trimEnd() || '<empty>',
+      stdout.trimEnd() || '<empty>',
       '',
       'stderr:',
-      spawnResult.stderr.trimEnd() || '<empty>',
+      stderr.trimEnd() || '<empty>',
     ]);
     return { passed: false };
   } finally {

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -9,6 +9,8 @@ import { TEST_CASE_RESULT_PREFIX, testCaseResultSchema } from '../types/testCase
 import { printDebugBanner } from './printDebugBanner.js';
 import type { ResolvedCwd } from './resolveCwds.js';
 
+const ISOLATION_CHECK_TIMEOUT_MS = 30_000;
+
 export interface ProblemDirIsolationCheckResult {
   passed: boolean;
 }
@@ -30,11 +32,21 @@ export async function checkProblemDirIsolation(
     const relativeCwd = path.relative(problemDir, resolvedCwd.cwd);
     const copiedCwd = path.join(copiedProblemDir, relativeCwd);
     const scriptPath = getInvokedScriptPath(problemDir);
+    if (scriptPath.startsWith('..') || path.isAbsolute(scriptPath)) {
+      printDebugBanner([
+        '[DEBUG MODE] isolated problem directory check skipped',
+        '',
+        'The invoked judge script is located outside the problem directory.',
+        `Script path: ${scriptPath}`,
+      ]);
+      return { passed: true };
+    }
     const paramsJson = JSON.stringify(params) ?? '{}';
     const spawnResult = child_process.spawnSync('bun', ['run', scriptPath, copiedCwd, paramsJson], {
       cwd: copiedProblemDir,
       encoding: 'utf8',
       env: process.env,
+      timeout: ISOLATION_CHECK_TIMEOUT_MS,
     });
     const stdout = spawnResult.stdout ?? '';
     const stderr = spawnResult.stderr ?? '';

--- a/src/helpers/checkProblemDirIsolation.ts
+++ b/src/helpers/checkProblemDirIsolation.ts
@@ -27,12 +27,13 @@ export async function checkProblemDirIsolation(
   try {
     tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'problem-utils-isolation_'));
     const absoluteProblemDir = path.resolve(problemDir);
-    const copiedProblemDir = path.join(tempRoot, path.basename(absoluteProblemDir));
+    const copiedProblemDir = path.join(tempRoot, toTempRelativePath(absoluteProblemDir));
+    await fs.promises.mkdir(path.dirname(copiedProblemDir), { recursive: true });
     await fs.promises.cp(absoluteProblemDir, copiedProblemDir, {
       recursive: true,
       filter: isCopiedProblemPath,
     });
-    await symlinkAncestorNodeModules(tempRoot, absoluteProblemDir);
+    await symlinkAllAncestorNodeModules(tempRoot, absoluteProblemDir);
 
     const relativeCwd = path.relative(absoluteProblemDir, path.resolve(resolvedCwd.cwd));
     const copiedCwd = path.join(copiedProblemDir, relativeCwd);
@@ -112,31 +113,32 @@ function isIsolationExecArg(arg: string): boolean {
   return !arg.startsWith('--inspect') && !arg.startsWith('--watch') && !arg.startsWith('--hot');
 }
 
-async function symlinkAncestorNodeModules(tempRoot: string, problemDir: string): Promise<void> {
-  const ancestorNodeModulesPath = findAncestorNodeModulesPath(problemDir);
-  if (!ancestorNodeModulesPath) return;
-
-  try {
-    await fs.promises.symlink(
-      ancestorNodeModulesPath,
-      path.join(tempRoot, 'node_modules'),
-      process.platform === 'win32' ? 'junction' : 'dir'
-    );
-  } catch {
-    // Package resolution is best-effort; the isolation check still reports a clear spawn failure if imports break.
-  }
-}
-
-function findAncestorNodeModulesPath(problemDir: string): string | undefined {
+async function symlinkAllAncestorNodeModules(tempRoot: string, problemDir: string): Promise<void> {
   let currentDir = path.resolve(problemDir);
   while (true) {
     const nodeModulesPath = path.join(currentDir, 'node_modules');
-    if (fs.existsSync(nodeModulesPath)) return nodeModulesPath;
+    if (fs.existsSync(nodeModulesPath)) {
+      const targetSymlinkPath = path.join(tempRoot, toTempRelativePath(currentDir), 'node_modules');
+      try {
+        await fs.promises.mkdir(path.dirname(targetSymlinkPath), { recursive: true });
+        await fs.promises.symlink(
+          nodeModulesPath,
+          targetSymlinkPath,
+          process.platform === 'win32' ? 'junction' : 'dir'
+        );
+      } catch {
+        // Package resolution is best-effort; the isolation check still reports a clear spawn failure if imports break.
+      }
+    }
 
     const parentDir = path.dirname(currentDir);
-    if (parentDir === currentDir) return undefined;
+    if (parentDir === currentDir) break;
     currentDir = parentDir;
   }
+}
+
+function toTempRelativePath(absolutePath: string): string {
+  return absolutePath.replace(/^([a-zA-Z]):/, '$1');
 }
 
 function getInvokedScriptPath(problemDir: string): string {

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -135,7 +135,10 @@ export async function commandJudgePreset<
     const acceptedCwd = cwds.find((cwd) => cwd.expectedResult === 'accepted');
     if (acceptedCwd) {
       const isolationCheckResult = await checkProblemDirIsolation(problemDir, acceptedCwd, params);
-      if (!isolationCheckResult.passed) process.exitCode = 1;
+      if (!isolationCheckResult.passed) {
+        process.exitCode = 1;
+        return;
+      }
     } else {
       printDebugBanner([
         '[DEBUG MODE] isolated problem directory check skipped',

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -9,6 +9,7 @@ import { findEntryPointFile } from '../helpers/findEntryPointFile.js';
 import { findLanguageDefinitionByPath } from '../helpers/findLanguageDefinitionByPath.js';
 import { judgeByStaticAnalysis } from '../helpers/judgeByStaticAnalysis.js';
 import { parseArgs } from '../helpers/parseArgs.js';
+import { printDebugBanner } from '../helpers/printDebugBanner.js';
 import { printTestCaseResult } from '../helpers/printTestCaseResult.js';
 import { readOutputFiles } from '../helpers/readOutputFiles.js';
 import { readProblemMarkdownFrontMatter } from '../helpers/readProblemMarkdownFrontMatter.js';
@@ -131,8 +132,17 @@ export async function commandJudgePreset<
   const { cwds, isDebugMode } = await resolveCwds(problemDir, args.cwd);
 
   if (isDebugMode) {
-    const isolationCheckResult = await checkProblemDirIsolation(problemDir, cwds[0]!, params);
-    if (!isolationCheckResult.passed) process.exitCode = 1;
+    const acceptedCwd = cwds.find((cwd) => cwd.expectedResult === 'accepted');
+    if (acceptedCwd) {
+      const isolationCheckResult = await checkProblemDirIsolation(problemDir, acceptedCwd, params);
+      if (!isolationCheckResult.passed) process.exitCode = 1;
+    } else {
+      printDebugBanner([
+        '[DEBUG MODE] isolated problem directory check skipped',
+        '',
+        'No accepted model answer is available for checking that the copied judge still accepts a valid submission.',
+      ]);
+    }
   }
 
   for (const resolvedCwd of cwds) {

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { z } from 'zod';
 
+import { checkProblemDirIsolation } from '../helpers/checkProblemDirIsolation.js';
 import { cleanWorkingDirectory, snapshotWorkingDirectory } from '../helpers/cleanWorkingDirectory.js';
 import { copyTestCaseFileInput } from '../helpers/copyTestCaseFileInput.js';
 import { findEntryPointFile } from '../helpers/findEntryPointFile.js';
@@ -128,6 +129,11 @@ export async function commandJudgePreset<
   const params = judgeParamsSchema.parse(args.params);
 
   const { cwds, isDebugMode } = await resolveCwds(problemDir, args.cwd);
+
+  if (isDebugMode) {
+    const isolationCheckResult = await checkProblemDirIsolation(problemDir, cwds[0]!, params);
+    if (!isolationCheckResult.passed) process.exitCode = 1;
+  }
 
   for (const resolvedCwd of cwds) {
     if (isDebugMode) printDebugCwdBanner(problemDir, resolvedCwd);


### PR DESCRIPTION
## Customer Summary

- Adds an automatic debug-mode check that catches `judge.ts` dependencies on files outside the problem directory before a problem is submitted to Exercode.
- When `commandJudgePreset` runs without a cwd, it now copies the problem into a temporary isolated location and verifies an accepted model answer there before normal debug judging.
- If the copied judge cannot run or does not accept the accepted model answer, debug mode prints a clear failure banner and exits non-zero.

## Technical Summary

- Added `checkProblemDirIsolation` and wired it into `commandJudgePreset` debug mode before iterating model answers.
- The isolation check copies the problem directory to `os.tmpdir()`, excludes unnecessary directories such as `node_modules` and `.git`, mirrors ancestor paths for module resolution, and symlinks ancestor `node_modules` directories for monorepo/hoisted dependencies.
- The copied judge is spawned with the same runtime (`process.execPath`) and safe `execArgv`, with inspect/watch/hot flags filtered and a 30-second timeout.
- The nested judge output is captured and parsed via `TEST_CASE_RESULT`; the check requires emitted results to be accepted and avoids leaking nested result lines to parent stdout.
- Debug mode skips the isolation check when no accepted model answer exists or when the invoked judge script is outside the problem directory.

## Why

- A judge can pass local source-tree debug runs while failing on Exercode if it imports helper files outside the problem payload, such as `../../../test/...`.
- Exercode executes a problem from a temporary directory containing only that problem's files, so debug mode should exercise the same isolation constraint.

## Testing

- `yarn format-code && yarn typecheck && yarn lint && yarn verify`
- `/bin/zsh -lc 'yarn build'`
- Manual success check with a temporary problem whose copied `judge.ts` ran successfully and printed `[DEBUG MODE] isolated problem directory check passed`.
- Manual failure check with a temporary problem whose `judge.ts` or test logic depended on a file outside the copied problem directory; debug mode printed the isolated check failure and exited with status `1`.
- Manual skip check with only `model_answers.fails`, confirming debug mode skips isolation and exits successfully.
- Manual spawn-failure check, confirming failure details are printed instead of crashing.
- Manual subdirectory check with `src/judge.ts`, confirming the copied judge path resolves correctly.
