### PR TITLE
fix: optionally install temporary project dependencies

### DIFF
--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -139,7 +139,7 @@ export async function runCommandInTemporaryPackageManagerProject(
         options,
         result: {
           ...result,
-          timeSeconds: elapsedTimeSeconds,
+          timeSeconds: installResult.timeSeconds + result.timeSeconds,
           memoryBytes: Math.max(installResult.memoryBytes, result.memoryBytes),
         },
       });

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -22,6 +22,10 @@ export interface RunCommandInTemporaryPackageManagerProjectOptions {
   projectDir: string;
   packageManager: PackageManager;
   command: readonly [string, ...string[]] | ((context: { runDir: string }) => readonly [string, ...string[]]);
+  install?:
+    | boolean
+    | readonly [string, ...string[]]
+    | ((context: { runDir: string }) => readonly [string, ...string[]]);
   stdin?: string;
   env?: NodeJS.ProcessEnv;
   timeLimitSeconds: number;
@@ -52,14 +56,21 @@ const packageManagerProjectFilePaths = {
   yarn: ['package.json', 'yarn.lock', '.yarnrc.yml', '.yarn'],
 } as const satisfies Record<PackageManager, readonly string[]>;
 
+const packageManagerInstallCommands: Partial<Record<PackageManager, readonly [string, ...string[]]>> = {
+  bun: ['bun', 'install', '--silent'],
+  npm: ['npm', 'install', '--silent'],
+  pnpm: ['pnpm', 'install', '--silent'],
+  yarn: ['yarn', 'install', '--silent'],
+};
+
 const defaultOutputLimitBytes = 50 * 1024 * 1024;
 const killGracePeriodMilliseconds = 1000;
 const timeCommand = resolveTimeCommand();
 
 /**
  * Copies a submission directory to a temporary directory, overlays package
- * manager project files from the problem directory, runs a command, and then
- * removes the temporary directory.
+ * manager project files from the problem directory, optionally installs
+ * dependencies, runs a command, and then removes the temporary directory.
  */
 export async function runCommandInTemporaryPackageManagerProject(
   options: RunCommandInTemporaryPackageManagerProjectOptions
@@ -74,31 +85,128 @@ export async function runCommandInTemporaryPackageManagerProject(
       projectFilePaths: options.projectFilePaths,
     });
 
+    const env = options.env ? { ...process.env, ...options.env } : process.env;
+    const installCommand = resolveInstallCommand(options, runDir);
     const command = typeof options.command === 'function' ? options.command({ runDir }) : options.command;
     const startedAt = Date.now();
+    const outputLimitBytes = options.outputLimitBytes ?? defaultOutputLimitBytes;
+    let installResult: Awaited<ReturnType<typeof spawnWithInput>> | undefined;
+    let remainingOutputLimitBytes = outputLimitBytes;
+
+    if (installCommand) {
+      installResult = await spawnWithInput(installCommand, {
+        cwd: runDir,
+        env,
+        outputLimitBytes,
+        stdin: '',
+        timeLimitSeconds: options.timeLimitSeconds,
+      });
+      remainingOutputLimitBytes -= outputByteLength(installResult.stdout) + outputByteLength(installResult.stderr);
+      if (isFailedSpawnResult(installResult)) {
+        return toPackageManagerCommandRunResult({
+          elapsedTimeSeconds: (Date.now() - startedAt) / 1000,
+          options,
+          result: installResult,
+        });
+      }
+      if (remainingOutputLimitBytes <= 0) {
+        return {
+          ...toPackageManagerCommandRunResult({
+            elapsedTimeSeconds: (Date.now() - startedAt) / 1000,
+            options,
+            result: installResult,
+          }),
+          outputLimitExceeded: true,
+          status: 0,
+        };
+      }
+    }
+
+    const remainingTimeLimitSeconds = options.timeLimitSeconds - (Date.now() - startedAt) / 1000;
+    if (remainingTimeLimitSeconds <= 0) {
+      return {
+        stdin: options.stdin ?? '',
+        stdout: installResult?.stdout ?? '',
+        stderr: installResult?.stderr ?? '',
+        status: 0,
+        timeSeconds: options.timeLimitSeconds + 1e-3,
+        memoryBytes: installResult?.memoryBytes ?? 0,
+        timedOut: true,
+        signal: installResult?.signal,
+        outputLimitExceeded: false,
+      };
+    }
+
     const result = await spawnWithInput(command, {
       cwd: runDir,
-      env: options.env ? { ...process.env, ...options.env } : process.env,
-      outputLimitBytes: options.outputLimitBytes ?? defaultOutputLimitBytes,
+      env,
+      outputLimitBytes: remainingOutputLimitBytes,
       stdin: options.stdin ?? '',
-      timeLimitSeconds: options.timeLimitSeconds,
+      timeLimitSeconds: remainingTimeLimitSeconds,
     });
     const elapsedTimeSeconds = (Date.now() - startedAt) / 1000;
 
-    return {
-      stdin: options.stdin ?? '',
-      stdout: result.stdout,
-      stderr: result.stderr,
-      status: result.timedOut || result.outputLimitExceeded ? 0 : result.status,
-      timeSeconds: result.timedOut ? options.timeLimitSeconds + 1e-3 : result.timeSeconds || elapsedTimeSeconds,
-      memoryBytes: result.memoryBytes,
-      timedOut: result.timedOut,
-      signal: result.signal,
-      outputLimitExceeded: result.outputLimitExceeded,
-    };
+    if (installResult) {
+      return toPackageManagerCommandRunResult({
+        elapsedTimeSeconds,
+        options,
+        result: {
+          ...result,
+          stdout: installResult.stdout + result.stdout,
+          stderr: installResult.stderr + result.stderr,
+          timeSeconds: elapsedTimeSeconds,
+          memoryBytes: Math.max(installResult.memoryBytes, result.memoryBytes),
+        },
+      });
+    }
+
+    return toPackageManagerCommandRunResult({ elapsedTimeSeconds, options, result });
   } finally {
     await fs.rm(runDir, { force: true, recursive: true });
   }
+}
+
+function toPackageManagerCommandRunResult(context: {
+  elapsedTimeSeconds: number;
+  options: RunCommandInTemporaryPackageManagerProjectOptions;
+  result: Awaited<ReturnType<typeof spawnWithInput>>;
+}): PackageManagerCommandRunResult {
+  return {
+    stdin: context.options.stdin ?? '',
+    stdout: context.result.stdout,
+    stderr: context.result.stderr,
+    status: context.result.timedOut || context.result.outputLimitExceeded ? 0 : context.result.status,
+    timeSeconds: context.result.timedOut
+      ? context.options.timeLimitSeconds + 1e-3
+      : context.result.timeSeconds || context.elapsedTimeSeconds,
+    memoryBytes: context.result.memoryBytes,
+    timedOut: context.result.timedOut,
+    signal: context.result.signal,
+    outputLimitExceeded: context.result.outputLimitExceeded,
+  };
+}
+
+function resolveInstallCommand(
+  options: RunCommandInTemporaryPackageManagerProjectOptions,
+  runDir: string
+): readonly [string, ...string[]] | undefined {
+  if (!options.install) return undefined;
+  if (options.install === true) {
+    const installCommand = packageManagerInstallCommands[options.packageManager];
+    if (installCommand === undefined) {
+      throw new Error(`No default install command is available for package manager: ${options.packageManager}`);
+    }
+    return installCommand;
+  }
+  return typeof options.install === 'function' ? options.install({ runDir }) : options.install;
+}
+
+function outputByteLength(output: string): number {
+  return Buffer.byteLength(output);
+}
+
+function isFailedSpawnResult(result: Awaited<ReturnType<typeof spawnWithInput>>): boolean {
+  return result.status !== 0 || result.timedOut || result.outputLimitExceeded;
 }
 
 export async function copyPackageManagerProjectFiles(options: {

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -91,7 +91,6 @@ export async function runCommandInTemporaryPackageManagerProject(
     const startedAt = Date.now();
     const outputLimitBytes = options.outputLimitBytes ?? defaultOutputLimitBytes;
     let installResult: Awaited<ReturnType<typeof spawnWithInput>> | undefined;
-    let remainingOutputLimitBytes = outputLimitBytes;
 
     if (installCommand) {
       installResult = await spawnWithInput(installCommand, {
@@ -101,24 +100,12 @@ export async function runCommandInTemporaryPackageManagerProject(
         stdin: '',
         timeLimitSeconds: options.timeLimitSeconds,
       });
-      remainingOutputLimitBytes -= outputByteLength(installResult.stdout) + outputByteLength(installResult.stderr);
       if (isFailedSpawnResult(installResult)) {
         return toPackageManagerCommandRunResult({
           elapsedTimeSeconds: (Date.now() - startedAt) / 1000,
           options,
           result: installResult,
         });
-      }
-      if (remainingOutputLimitBytes <= 0) {
-        return {
-          ...toPackageManagerCommandRunResult({
-            elapsedTimeSeconds: (Date.now() - startedAt) / 1000,
-            options,
-            result: installResult,
-          }),
-          outputLimitExceeded: true,
-          status: 0,
-        };
       }
     }
 
@@ -140,7 +127,7 @@ export async function runCommandInTemporaryPackageManagerProject(
     const result = await spawnWithInput(command, {
       cwd: runDir,
       env,
-      outputLimitBytes: remainingOutputLimitBytes,
+      outputLimitBytes,
       stdin: options.stdin ?? '',
       timeLimitSeconds: remainingTimeLimitSeconds,
     });
@@ -152,8 +139,6 @@ export async function runCommandInTemporaryPackageManagerProject(
         options,
         result: {
           ...result,
-          stdout: installResult.stdout + result.stdout,
-          stderr: installResult.stderr + result.stderr,
           timeSeconds: elapsedTimeSeconds,
           memoryBytes: Math.max(installResult.memoryBytes, result.memoryBytes),
         },
@@ -199,10 +184,6 @@ function resolveInstallCommand(
     return installCommand;
   }
   return typeof options.install === 'function' ? options.install({ runDir }) : options.install;
-}
-
-function outputByteLength(output: string): number {
-  return Buffer.byteLength(output);
 }
 
 function isFailedSpawnResult(result: Awaited<ReturnType<typeof spawnWithInput>>): boolean {


### PR DESCRIPTION
## Customer Summary

- Judges can now opt in to installing dependencies in temporary package-manager projects before running submitted code.
- This prevents package managers such as Bun from auto-installing unexpected package versions when a copied `package.json` is intended to pin dependencies.
- Existing callers keep the same behavior unless they pass the new `install` option.

## Technical Summary

- Added `install` to `RunCommandInTemporaryPackageManagerProjectOptions`.
- Supports built-in install commands for `bun`, `npm`, `pnpm`, and `yarn` when `install: true` is used.
- Supports custom install commands via tuple or callback for other package managers or stricter workflows.
- Preserves submitted stdin for the actual command by running install with empty stdin.
- Keeps install stdout/stderr out of successful command results while preserving install failure output.
- Combines install and command timing/memory data without discarding precise `/usr/bin/time` measurements.

## Why

- SmartSE TypeScript judges copied problem `package.json` files but did not install dependencies before `bun run main.ts`.
- Bun auto-install then resolved packages from import specifiers and could ignore the intended pinned dependency version.
- Putting the dependency-install behavior in the shared helper avoids repeating shell workarounds in each judge.

## Testing

- `yarn typecheck`
- `yarn lint`
- `yarn build`
- Manual `dist` smoke test using `runCommandInTemporaryPackageManagerProject({ packageManager: 'bun', install: true, ... })` with a temporary project depending on `is-number`; verified dependency import and stdin forwarding.
- `yarn verify`
- `bunx @willbooster-private/agentic-workflows@1.25.2 skills check-pr-ci`
