### PR TITLE
fix: prepare temporary project dependencies by default

### DIFF
--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -69,8 +69,8 @@ const timeCommand = resolveTimeCommand();
 
 /**
  * Copies a submission directory to a temporary directory, overlays package
- * manager project files from the problem directory, optionally installs
- * dependencies, runs a command, and then removes the temporary directory.
+ * manager project files from the problem directory, prepares dependencies,
+ * runs a command, and then removes the temporary directory.
  */
 export async function runCommandInTemporaryPackageManagerProject(
   options: RunCommandInTemporaryPackageManagerProjectOptions
@@ -175,14 +175,9 @@ function resolveInstallCommand(
   options: RunCommandInTemporaryPackageManagerProjectOptions,
   runDir: string
 ): readonly [string, ...string[]] | undefined {
-  if (!options.install) return undefined;
-  if (options.install === true) {
-    const installCommand = packageManagerInstallCommands[options.packageManager];
-    if (installCommand === undefined) {
-      throw new Error(`No default install command is available for package manager: ${options.packageManager}`);
-    }
-    return installCommand;
-  }
+  if (options.install === false) return undefined;
+  if (options.install === undefined || options.install === true)
+    return packageManagerInstallCommands[options.packageManager];
   return typeof options.install === 'function' ? options.install({ runDir }) : options.install;
 }
 

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -176,8 +176,14 @@ function resolveInstallCommand(
   runDir: string
 ): readonly [string, ...string[]] | undefined {
   if (options.install === false) return undefined;
-  if (options.install === undefined || options.install === true)
-    return packageManagerInstallCommands[options.packageManager];
+  if (options.install === undefined) return packageManagerInstallCommands[options.packageManager];
+  if (options.install === true) {
+    const installCommand = packageManagerInstallCommands[options.packageManager];
+    if (installCommand === undefined) {
+      throw new Error(`No default install command is available for package manager: ${options.packageManager}`);
+    }
+    return installCommand;
+  }
   return typeof options.install === 'function' ? options.install({ runDir }) : options.install;
 }
 

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -22,10 +22,6 @@ export interface RunCommandInTemporaryPackageManagerProjectOptions {
   projectDir: string;
   packageManager: PackageManager;
   command: readonly [string, ...string[]] | ((context: { runDir: string }) => readonly [string, ...string[]]);
-  install?:
-    | boolean
-    | readonly [string, ...string[]]
-    | ((context: { runDir: string }) => readonly [string, ...string[]]);
   stdin?: string;
   env?: NodeJS.ProcessEnv;
   timeLimitSeconds: number;
@@ -86,7 +82,7 @@ export async function runCommandInTemporaryPackageManagerProject(
     });
 
     const env = options.env ? { ...process.env, ...options.env } : process.env;
-    const installCommand = resolveInstallCommand(options, runDir);
+    const installCommand = resolveInstallCommand(options.packageManager);
     const command = typeof options.command === 'function' ? options.command({ runDir }) : options.command;
     const startedAt = Date.now();
     const outputLimitBytes = options.outputLimitBytes ?? defaultOutputLimitBytes;
@@ -171,20 +167,8 @@ function toPackageManagerCommandRunResult(context: {
   };
 }
 
-function resolveInstallCommand(
-  options: RunCommandInTemporaryPackageManagerProjectOptions,
-  runDir: string
-): readonly [string, ...string[]] | undefined {
-  if (options.install === false) return undefined;
-  if (options.install === undefined) return packageManagerInstallCommands[options.packageManager];
-  if (options.install === true) {
-    const installCommand = packageManagerInstallCommands[options.packageManager];
-    if (installCommand === undefined) {
-      throw new Error(`No default install command is available for package manager: ${options.packageManager}`);
-    }
-    return installCommand;
-  }
-  return typeof options.install === 'function' ? options.install({ runDir }) : options.install;
+function resolveInstallCommand(packageManager: PackageManager): readonly [string, ...string[]] | undefined {
+  return packageManagerInstallCommands[packageManager];
 }
 
 function isFailedSpawnResult(result: Awaited<ReturnType<typeof spawnWithInput>>): boolean {


### PR DESCRIPTION
## Summary
- Prepare temporary project dependencies by default in `runCommandInTemporaryPackageManagerProject`.
- Remove the `install` option from the public API.
- Keep package managers without a separate preparation command, such as `uv`, as no-op so `uv run` can handle synchronization itself.

## Verification
- `yarn typecheck`
- `yarn format-code`
- `yarn build`
- smoke test for default npm install and uv no-op behavior
- `yarn verify`
