### PR TITLE
feat: run untrusted submitted programs as a sandbox OS user when delegated

### DIFF
--- a/example/file_command_min_length/judge.ts
+++ b/example/file_command_min_length/judge.ts
@@ -1,7 +1,10 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { DecisionCode } from '@exercode/problem-utils';
+import {
+  createDirectoryWithoutFollowingSymlinks,
+  DecisionCode,
+  writeFileWithoutFollowingSymlinks,
+} from '@exercode/problem-utils';
 import { commandJudgePreset } from '@exercode/problem-utils/presets/command';
 
 interface FixtureInput {
@@ -46,7 +49,7 @@ await commandJudgePreset<CommandExampleTestCase>(import.meta.dirname, {
     })),
   resolveInput: async ({ testCase, cwd }) => {
     const inputDirectoryPath = path.join(cwd, FIXTURE_ROOT, testCase.id);
-    await writeFixtureFiles(inputDirectoryPath, testCase.fixtureInput);
+    await writeFixtureFiles(cwd, inputDirectoryPath, testCase.fixtureInput);
     return path.relative(cwd, inputDirectoryPath);
   },
   test: ({ runResult, testCase }) => {
@@ -73,9 +76,12 @@ function toTokens(value: string): string[] {
     .filter((token) => token.length > 0);
 }
 
-async function writeFixtureFiles(basePath: string, files: FixtureInput): Promise<void> {
-  await fs.mkdir(basePath, { recursive: true });
+// This runs as the trusted harness user while `cwd` belongs to the submission, so it must not
+// follow a symlink the submission planted at a fixture path (or at one of its parents) — that
+// would hand the submission a write to a file only the harness can reach.
+async function writeFixtureFiles(cwd: string, basePath: string, files: FixtureInput): Promise<void> {
+  await createDirectoryWithoutFollowingSymlinks(cwd, basePath);
   for (const [fileName, content] of Object.entries(files)) {
-    await fs.writeFile(path.join(basePath, fileName), content);
+    await writeFileWithoutFollowingSymlinks(path.join(basePath, fileName), content);
   }
 }

--- a/src/helpers/cleanWorkingDirectory.ts
+++ b/src/helpers/cleanWorkingDirectory.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { forceRemove } from './sandboxUser.js';
+
 // Currently, it does not support changing file contents and deleting files.
 export async function snapshotWorkingDirectory(cwd: string): Promise<ReadonlySet<string>> {
   const paths = await fs.promises.readdir(cwd, { recursive: true });
@@ -10,6 +12,6 @@ export async function snapshotWorkingDirectory(cwd: string): Promise<ReadonlySet
 export async function cleanWorkingDirectory(cwd: string, snapshot: ReadonlySet<string>): Promise<void> {
   for (const p of await fs.promises.readdir(cwd, { recursive: true })) {
     if (snapshot.has(p)) continue;
-    await fs.promises.rm(path.join(cwd, p), { force: true, recursive: true });
+    await forceRemove(path.join(cwd, p));
   }
 }

--- a/src/helpers/cleanWorkingDirectory.ts
+++ b/src/helpers/cleanWorkingDirectory.ts
@@ -3,30 +3,36 @@ import path from 'node:path';
 
 import { forceRemove, relaxPermissionsAsSandboxUser, sandboxUserName } from './sandboxUser.js';
 
+/** Snapshot of the working directory: each entry's relative path and whether it was a directory. */
+export type WorkingDirectorySnapshot = ReadonlyMap<string, boolean>;
+
 // Currently, it does not support changing file contents and deleting files.
-export async function snapshotWorkingDirectory(cwd: string): Promise<ReadonlySet<string>> {
-  const snapshot = new Set<string>();
+export async function snapshotWorkingDirectory(cwd: string): Promise<WorkingDirectorySnapshot> {
+  const snapshot = new Map<string, boolean>();
   await collectEntries(cwd, cwd, snapshot);
   return snapshot;
 }
 
-export async function cleanWorkingDirectory(cwd: string, snapshot: ReadonlySet<string>): Promise<void> {
+export async function cleanWorkingDirectory(cwd: string, snapshot: WorkingDirectorySnapshot): Promise<void> {
   await removeUnsnapshotted(cwd, cwd, snapshot);
 }
 
-async function collectEntries(root: string, dir: string, into: Set<string>): Promise<void> {
+async function collectEntries(root: string, dir: string, into: Map<string, boolean>): Promise<void> {
   for (const entry of await readdirWithTypes(dir)) {
     const absolutePath = path.join(dir, entry.name);
-    into.add(path.relative(root, absolutePath));
+    into.set(path.relative(root, absolutePath), entry.isDirectory());
     // Never descend into a symlink: a sandboxed submission could point it outside the directory.
     if (entry.isDirectory()) await collectEntries(root, absolutePath, into);
   }
 }
 
-async function removeUnsnapshotted(root: string, dir: string, snapshot: ReadonlySet<string>): Promise<void> {
+async function removeUnsnapshotted(root: string, dir: string, snapshot: WorkingDirectorySnapshot): Promise<void> {
   for (const entry of await readdirWithTypes(dir)) {
     const absolutePath = path.join(dir, entry.name);
-    if (!snapshot.has(path.relative(root, absolutePath))) {
+    const snapshottedAsDirectory = snapshot.get(path.relative(root, absolutePath));
+    // The type must still match: a sandboxed submission can replace one of its own snapshotted
+    // entries with a symlink, and matching by path alone would preserve it across test cases.
+    if (snapshottedAsDirectory === undefined || snapshottedAsDirectory !== entry.isDirectory()) {
       // `absolutePath` has no symlink ancestor (we only recurse into real directories), and
       // `forceRemove`/`fs.rm` unlinks a leaf symlink instead of following it, so this cannot delete
       // outside the working directory even if the submission planted symlinks.

--- a/src/helpers/cleanWorkingDirectory.ts
+++ b/src/helpers/cleanWorkingDirectory.ts
@@ -1,17 +1,30 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { forceRemove } from './sandboxUser.js';
+import { forceRemove, relaxPermissionsAsSandboxUser, sandboxUserName } from './sandboxUser.js';
 
 // Currently, it does not support changing file contents and deleting files.
 export async function snapshotWorkingDirectory(cwd: string): Promise<ReadonlySet<string>> {
-  const paths = await fs.promises.readdir(cwd, { recursive: true });
-  return new Set(paths);
+  return new Set(await readdirRecursive(cwd));
 }
 
 export async function cleanWorkingDirectory(cwd: string, snapshot: ReadonlySet<string>): Promise<void> {
-  for (const p of await fs.promises.readdir(cwd, { recursive: true })) {
+  for (const p of await readdirRecursive(cwd)) {
     if (snapshot.has(p)) continue;
     await forceRemove(path.join(cwd, p));
+  }
+}
+
+/**
+ * Recursive readdir with a fallback for directories a sandboxed process created with restrictive
+ * permissions, which the harness user cannot traverse.
+ */
+async function readdirRecursive(cwd: string): Promise<string[]> {
+  try {
+    return await fs.promises.readdir(cwd, { recursive: true });
+  } catch (error) {
+    if (!sandboxUserName) throw error;
+    relaxPermissionsAsSandboxUser(cwd);
+    return await fs.promises.readdir(cwd, { recursive: true });
   }
 }

--- a/src/helpers/cleanWorkingDirectory.ts
+++ b/src/helpers/cleanWorkingDirectory.ts
@@ -5,26 +5,48 @@ import { forceRemove, relaxPermissionsAsSandboxUser, sandboxUserName } from './s
 
 // Currently, it does not support changing file contents and deleting files.
 export async function snapshotWorkingDirectory(cwd: string): Promise<ReadonlySet<string>> {
-  return new Set(await readdirRecursive(cwd));
+  const snapshot = new Set<string>();
+  await collectEntries(cwd, cwd, snapshot);
+  return snapshot;
 }
 
 export async function cleanWorkingDirectory(cwd: string, snapshot: ReadonlySet<string>): Promise<void> {
-  for (const p of await readdirRecursive(cwd)) {
-    if (snapshot.has(p)) continue;
-    await forceRemove(path.join(cwd, p));
+  await removeUnsnapshotted(cwd, cwd, snapshot);
+}
+
+async function collectEntries(root: string, dir: string, into: Set<string>): Promise<void> {
+  for (const entry of await readdirWithTypes(dir)) {
+    const absolutePath = path.join(dir, entry.name);
+    into.add(path.relative(root, absolutePath));
+    // Never descend into a symlink: a sandboxed submission could point it outside the directory.
+    if (entry.isDirectory()) await collectEntries(root, absolutePath, into);
+  }
+}
+
+async function removeUnsnapshotted(root: string, dir: string, snapshot: ReadonlySet<string>): Promise<void> {
+  for (const entry of await readdirWithTypes(dir)) {
+    const absolutePath = path.join(dir, entry.name);
+    if (!snapshot.has(path.relative(root, absolutePath))) {
+      // `absolutePath` has no symlink ancestor (we only recurse into real directories), and
+      // `forceRemove`/`fs.rm` unlinks a leaf symlink instead of following it, so this cannot delete
+      // outside the working directory even if the submission planted symlinks.
+      await forceRemove(absolutePath);
+      continue;
+    }
+    if (entry.isDirectory()) await removeUnsnapshotted(root, absolutePath, snapshot);
   }
 }
 
 /**
- * Recursive readdir with a fallback for directories a sandboxed process created with restrictive
- * permissions, which the harness user cannot traverse.
+ * `readdir` with entry types (which reflect `lstat`, so a symlink reads as a symlink, not a
+ * directory), with a fallback for directories a sandboxed process made untraversable.
  */
-async function readdirRecursive(cwd: string): Promise<string[]> {
+async function readdirWithTypes(dir: string): Promise<fs.Dirent[]> {
   try {
-    return await fs.promises.readdir(cwd, { recursive: true });
+    return await fs.promises.readdir(dir, { withFileTypes: true });
   } catch (error) {
     if (!sandboxUserName) throw error;
-    relaxPermissionsAsSandboxUser(cwd);
-    return await fs.promises.readdir(cwd, { recursive: true });
+    relaxPermissionsAsSandboxUser(dir);
+    return await fs.promises.readdir(dir, { withFileTypes: true });
   }
 }

--- a/src/helpers/cleanWorkingDirectory.ts
+++ b/src/helpers/cleanWorkingDirectory.ts
@@ -3,12 +3,14 @@ import path from 'node:path';
 
 import { forceRemove, relaxPermissionsAsSandboxUser, sandboxUserName } from './sandboxUser.js';
 
-/** Snapshot of the working directory: each entry's relative path and whether it was a directory. */
-export type WorkingDirectorySnapshot = ReadonlyMap<string, boolean>;
+/** Snapshot of the working directory: each entry's relative path and the kind of entry it was. */
+export type WorkingDirectorySnapshot = ReadonlyMap<string, WorkingDirectoryEntryKind>;
+
+type WorkingDirectoryEntryKind = 'directory' | 'file' | 'symlink' | 'other';
 
 // Currently, it does not support changing file contents and deleting files.
 export async function snapshotWorkingDirectory(cwd: string): Promise<WorkingDirectorySnapshot> {
-  const snapshot = new Map<string, boolean>();
+  const snapshot = new Map<string, WorkingDirectoryEntryKind>();
   await collectEntries(cwd, cwd, snapshot);
   return snapshot;
 }
@@ -17,10 +19,10 @@ export async function cleanWorkingDirectory(cwd: string, snapshot: WorkingDirect
   await removeUnsnapshotted(cwd, cwd, snapshot);
 }
 
-async function collectEntries(root: string, dir: string, into: Map<string, boolean>): Promise<void> {
+async function collectEntries(root: string, dir: string, into: Map<string, WorkingDirectoryEntryKind>): Promise<void> {
   for (const entry of await readdirWithTypes(dir)) {
     const absolutePath = path.join(dir, entry.name);
-    into.set(path.relative(root, absolutePath), entry.isDirectory());
+    into.set(path.relative(root, absolutePath), toEntryKind(entry));
     // Never descend into a symlink: a sandboxed submission could point it outside the directory.
     if (entry.isDirectory()) await collectEntries(root, absolutePath, into);
   }
@@ -29,10 +31,10 @@ async function collectEntries(root: string, dir: string, into: Map<string, boole
 async function removeUnsnapshotted(root: string, dir: string, snapshot: WorkingDirectorySnapshot): Promise<void> {
   for (const entry of await readdirWithTypes(dir)) {
     const absolutePath = path.join(dir, entry.name);
-    const snapshottedAsDirectory = snapshot.get(path.relative(root, absolutePath));
-    // The type must still match: a sandboxed submission can replace one of its own snapshotted
+    const snapshottedKind = snapshot.get(path.relative(root, absolutePath));
+    // The kind must still match: a sandboxed submission can replace one of its own snapshotted
     // entries with a symlink, and matching by path alone would preserve it across test cases.
-    if (snapshottedAsDirectory === undefined || snapshottedAsDirectory !== entry.isDirectory()) {
+    if (snapshottedKind === undefined || snapshottedKind !== toEntryKind(entry)) {
       // `absolutePath` has no symlink ancestor (we only recurse into real directories), and
       // `forceRemove`/`fs.rm` unlinks a leaf symlink instead of following it, so this cannot delete
       // outside the working directory even if the submission planted symlinks.
@@ -41,6 +43,13 @@ async function removeUnsnapshotted(root: string, dir: string, snapshot: WorkingD
     }
     if (entry.isDirectory()) await removeUnsnapshotted(root, absolutePath, snapshot);
   }
+}
+
+function toEntryKind(entry: fs.Dirent): WorkingDirectoryEntryKind {
+  if (entry.isSymbolicLink()) return 'symlink';
+  if (entry.isDirectory()) return 'directory';
+  if (entry.isFile()) return 'file';
+  return 'other';
 }
 
 /**

--- a/src/helpers/copyTestCaseFileInput.ts
+++ b/src/helpers/copyTestCaseFileInput.ts
@@ -4,11 +4,14 @@ import { copyWithoutFollowingSymlinks } from './safeFs.js';
 import { makeAccessibleToSandboxUser } from './sandboxUser.js';
 
 export async function copyTestCaseFileInput(fileInputPath: string, cwd: string): Promise<void> {
-  // `readTestCases` only ever yields a `.fin` directory here, and the destination is the working
-  // directory itself, so a file-typed source would mean replacing that whole directory with a file.
-  const fileInputStats = await fs.promises.stat(fileInputPath);
+  // `readTestCases` only ever yields a real `.fin` directory here (it selects entries by
+  // `dirent.isDirectory()`, which does not follow links), and the destination is the working
+  // directory itself, so anything else would mean replacing that whole directory — with a file, or
+  // with a symlink to the problem's test cases. `lstat`, not `stat`: the latter resolves a symlink
+  // source and would report it as a directory.
+  const fileInputStats = await fs.promises.lstat(fileInputPath);
   if (!fileInputStats.isDirectory()) {
-    throw new Error(`test case file input must be a directory: ${fileInputPath}`);
+    throw new Error(`test case file input must be a directory, not a symlink or file: ${fileInputPath}`);
   }
   // A no-follow copy: a sandboxed submission may have planted a symlink at one of these
   // destination paths to redirect this trusted-user write outside its working directory.

--- a/src/helpers/copyTestCaseFileInput.ts
+++ b/src/helpers/copyTestCaseFileInput.ts
@@ -1,7 +1,15 @@
-import { makeAccessibleToSandboxUser } from './sandboxUser.js';
+import fs from 'node:fs';
+
 import { copyWithoutFollowingSymlinks } from './safeFs.js';
+import { makeAccessibleToSandboxUser } from './sandboxUser.js';
 
 export async function copyTestCaseFileInput(fileInputPath: string, cwd: string): Promise<void> {
+  // `readTestCases` only ever yields a `.fin` directory here, and the destination is the working
+  // directory itself, so a file-typed source would mean replacing that whole directory with a file.
+  const fileInputStats = await fs.promises.stat(fileInputPath);
+  if (!fileInputStats.isDirectory()) {
+    throw new Error(`test case file input must be a directory: ${fileInputPath}`);
+  }
   // A no-follow copy: a sandboxed submission may have planted a symlink at one of these
   // destination paths to redirect this trusted-user write outside its working directory.
   await copyWithoutFollowingSymlinks(fileInputPath, cwd);

--- a/src/helpers/copyTestCaseFileInput.ts
+++ b/src/helpers/copyTestCaseFileInput.ts
@@ -1,9 +1,10 @@
-import fs from 'node:fs';
-
 import { makeAccessibleToSandboxUser } from './sandboxUser.js';
+import { copyWithoutFollowingSymlinks } from './safeFs.js';
 
 export async function copyTestCaseFileInput(fileInputPath: string, cwd: string): Promise<void> {
-  await fs.promises.cp(fileInputPath, cwd, { force: true, recursive: true });
+  // A no-follow copy: a sandboxed submission may have planted a symlink at one of these
+  // destination paths to redirect this trusted-user write outside its working directory.
+  await copyWithoutFollowingSymlinks(fileInputPath, cwd);
   // The copied files are owned by the harness user; the sandboxed submission must read them and
   // may create outputs in the copied directories.
   makeAccessibleToSandboxUser(cwd);

--- a/src/helpers/copyTestCaseFileInput.ts
+++ b/src/helpers/copyTestCaseFileInput.ts
@@ -1,5 +1,10 @@
 import fs from 'node:fs';
 
+import { makeAccessibleToSandboxUser } from './sandboxUser.js';
+
 export async function copyTestCaseFileInput(fileInputPath: string, cwd: string): Promise<void> {
   await fs.promises.cp(fileInputPath, cwd, { force: true, recursive: true });
+  // The copied files are owned by the harness user; the sandboxed submission must read them and
+  // may create outputs in the copied directories.
+  makeAccessibleToSandboxUser(cwd);
 }

--- a/src/helpers/readOutputFiles.ts
+++ b/src/helpers/readOutputFiles.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { TestCaseResult } from '../types/testCaseResult.js';
 
 import { encodeFileForTestCaseResult } from './printTestCaseResult.js';
+import { isContainedPath } from './safeFs.js';
 import { sandboxUserName } from './sandboxUser.js';
 
 export async function readOutputFiles(
@@ -37,9 +38,7 @@ export async function isSafeSubmissionOutputPath(cwd: string, filePath: string):
   try {
     const realFilePath = await fs.promises.realpath(filePath);
     const realCwd = await fs.promises.realpath(cwd);
-    const relativePath = path.relative(realCwd, realFilePath);
-    // A bare `..`-prefix test would also reject an in-directory name like `..result`.
-    return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
+    return isContainedPath(realCwd, realFilePath);
   } catch {
     return false;
   }

--- a/src/helpers/readOutputFiles.ts
+++ b/src/helpers/readOutputFiles.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { TestCaseResult } from '../types/testCaseResult.js';
 
 import { encodeFileForTestCaseResult } from './printTestCaseResult.js';
+import { sandboxUserName } from './sandboxUser.js';
 
 export async function readOutputFiles(
   cwd: string,
@@ -12,11 +13,32 @@ export async function readOutputFiles(
   const outputFiles: NonNullable<TestCaseResult['outputFiles']> = [];
   for (const filePath of outputFilePaths) {
     try {
-      const buffer = await fs.promises.readFile(path.join(cwd, filePath));
+      const resolvedPath = path.join(cwd, filePath);
+      if (!(await isSafeSubmissionOutputPath(cwd, resolvedPath))) continue;
+      const buffer = await fs.promises.readFile(resolvedPath);
       outputFiles.push(encodeFileForTestCaseResult(filePath, buffer));
     } catch {
       // file not found
     }
   }
   return outputFiles;
+}
+
+/**
+ * Whether the harness may read the given submission-created path. When submissions run as the
+ * sandbox user while the harness is trusted, a submission could plant a symlink (or a symlinked
+ * parent directory) escaping its working directory — e.g. to the 0700 problem directory — and the
+ * privileged read would exfiltrate protected bytes, so only paths that resolve inside the working
+ * directory are allowed. Without user separation the submission can read those targets itself, so
+ * the check is skipped to keep authoring behavior unchanged.
+ */
+export async function isSafeSubmissionOutputPath(cwd: string, filePath: string): Promise<boolean> {
+  if (!sandboxUserName) return true;
+  try {
+    const realFilePath = await fs.promises.realpath(filePath);
+    const realCwd = await fs.promises.realpath(cwd);
+    return !path.relative(realCwd, realFilePath).startsWith('..');
+  } catch {
+    return false;
+  }
 }

--- a/src/helpers/readOutputFiles.ts
+++ b/src/helpers/readOutputFiles.ts
@@ -37,7 +37,9 @@ export async function isSafeSubmissionOutputPath(cwd: string, filePath: string):
   try {
     const realFilePath = await fs.promises.realpath(filePath);
     const realCwd = await fs.promises.realpath(cwd);
-    return !path.relative(realCwd, realFilePath).startsWith('..');
+    const relativePath = path.relative(realCwd, realFilePath);
+    // A bare `..`-prefix test would also reject an in-directory name like `..result`.
+    return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
   } catch {
     return false;
   }

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -358,6 +358,9 @@ export async function copyPackageManagerProjectFiles(options: {
 
 async function copyPathIfExists(sourcePath: string, destinationPath: string, runDir: string): Promise<void> {
   try {
+    // Before touching the destination: creating the parent levels replaces whatever the submission
+    // put there, which must not happen for a project file the problem does not even ship.
+    await fs.lstat(sourcePath);
     // No-follow copy: the destination was seeded from the (sandbox-writable) submission tree, so a
     // planted symlink there — at the destination itself or at any directory level of a nested
     // project file path — must not redirect this trusted project-file overlay outside runDir.
@@ -581,6 +584,10 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
   }
 }
 
+function isErrorWithCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && (error as { code: unknown }).code === code;
+}
+
 async function readTimeResult(timeOutputPath: string): Promise<{ timeSeconds: number; memoryBytes: number }> {
   // The submission owns this directory and can put anything at this path, so decide what was
   // opened from the handle itself rather than from a prior `lstat` it could race:
@@ -589,6 +596,10 @@ async function readTimeResult(timeOutputPath: string): Promise<{ timeSeconds: nu
   //   time and memory usage;
   // - `O_NONBLOCK` keeps a planted FIFO from blocking the harness forever waiting for a writer;
   // - the `fstat` then rejects anything that is not a regular file.
+  //
+  // Only an absent file means "no measurement" (the command was killed before `time` wrote one).
+  // Anything else at this path is the submission tampering with its own accounting — reporting zero
+  // memory would let it slip past a memory limit — so that fails the run instead.
   let content: string;
   let fileHandle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
@@ -597,11 +608,11 @@ async function readTimeResult(timeOutputPath: string): Promise<{ timeSeconds: nu
       nodeFs.constants.O_RDONLY | nodeFs.constants.O_NOFOLLOW | nodeFs.constants.O_NONBLOCK
     );
     const stats = await fileHandle.stat();
-    if (!stats.isFile()) return { timeSeconds: 0, memoryBytes: 0 };
+    if (!stats.isFile()) throw new Error(`${timeOutputPath} is not a regular file`);
     content = await fileHandle.readFile('utf8');
-  } catch {
-    // Whatever the submission swapped in, there is no measurement to report.
-    return { timeSeconds: 0, memoryBytes: 0 };
+  } catch (error) {
+    if (isErrorWithCode(error, 'ENOENT')) return { timeSeconds: 0, memoryBytes: 0 };
+    throw new Error(`failed to read the time measurement at ${timeOutputPath}`, { cause: error });
   } finally {
     await fileHandle?.close();
   }

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -11,6 +11,7 @@ import {
   sandboxUserName,
   wrapCommandWithSandboxUser,
 } from './sandboxUser.js';
+import { copyWithoutFollowingSymlinks } from './safeFs.js';
 
 export type PackageManager = 'bun' | 'cargo' | 'go' | 'gradle' | 'maven' | 'npm' | 'pnpm' | 'ruby' | 'uv' | 'yarn';
 type PackageManagerInstallCommand = readonly [string, ...string[]];
@@ -85,6 +86,9 @@ const timeCommand = resolveTimeCommand();
  * Copies a submission directory to a temporary directory, overlays package
  * manager project files from the problem directory, prepares dependencies,
  * runs a command, and then removes the temporary directory.
+ *
+ * Under `EXERCODE_SANDBOX_USER` delegation, cleanup kills every process of the sandbox user, so do
+ * not run multiple invocations concurrently in that mode — one finishing would kill the others.
  */
 export async function runCommandInTemporaryPackageManagerProject(
   options: RunCommandInTemporaryPackageManagerProjectOptions
@@ -340,7 +344,9 @@ export async function copyPackageManagerProjectFiles(options: {
 
 async function copyPathIfExists(sourcePath: string, destinationPath: string): Promise<void> {
   try {
-    await fs.cp(sourcePath, destinationPath, { recursive: true });
+    // No-follow copy: the destination was seeded from the (sandbox-writable) submission tree, so a
+    // planted symlink there must not redirect this trusted project-file overlay outside runDir.
+    await copyWithoutFollowingSymlinks(sourcePath, destinationPath);
   } catch (error) {
     const code =
       typeof error === 'object' && error !== null && 'code' in error ? (error as { code: unknown }).code : undefined;

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import {
   forceRemove,
   getSandboxUserEnvOverrides,
+  isSandboxWrappedCommand,
   killSandboxUserProcesses,
   makeAccessibleToSandboxUser,
   sandboxUserName,
@@ -378,7 +379,9 @@ async function spawnWithInput(
     timeCommand === undefined
       ? command
       : ([...timeCommand, `--output=${timeOutputPath}`, ...command] as [string, ...string[]]);
-  const spawnedCommand = wrapCommandWithSandboxUser(timedCommand);
+  // A caller may pass a command the presets already wrapped; wrapping the `time`-prefixed form
+  // again would nest `sudo` inside `sudo` and run the inner one as the unauthorized sandbox user.
+  const spawnedCommand = isSandboxWrappedCommand(command) ? timedCommand : wrapCommandWithSandboxUser(timedCommand);
   const subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
     cwd: context.cwd,
     detached: process.platform !== 'win32',

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -3,6 +3,15 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import {
+  forceRemove,
+  getSandboxUserEnvOverrides,
+  killSandboxUserProcesses,
+  makeAccessibleToSandboxUser,
+  sandboxUserName,
+  wrapCommandWithSandboxUser,
+} from './sandboxUser.js';
+
 export type PackageManager = 'bun' | 'cargo' | 'go' | 'gradle' | 'maven' | 'npm' | 'pnpm' | 'ruby' | 'uv' | 'yarn';
 type PackageManagerInstallCommand = readonly [string, ...string[]];
 
@@ -89,6 +98,9 @@ export async function runCommandInTemporaryPackageManagerProject(
       runDir,
       projectFilePaths: options.projectFilePaths,
     });
+    // The sandbox user (if any) runs the install/run commands below and must read the copied
+    // sources and create outputs (e.g. `node_modules`, `.venv`) next to them.
+    makeAccessibleToSandboxUser(runDir);
 
     const env = options.env ? { ...process.env, ...options.env } : process.env;
     const installCommand = await resolveInstallCommand(options.packageManager, runDir);
@@ -152,7 +164,7 @@ export async function runCommandInTemporaryPackageManagerProject(
 
     return toPackageManagerCommandRunResult({ elapsedTimeSeconds, options, result });
   } finally {
-    await fs.rm(runDir, { force: true, recursive: true });
+    await forceRemove(runDir);
   }
 }
 
@@ -354,12 +366,15 @@ async function spawnWithInput(
   outputLimitExceeded: boolean;
 }> {
   const timeOutputPath = timeCommand === undefined ? undefined : path.join(context.cwd, '.exercode-time-result');
-  const spawnedCommand =
-    timeCommand === undefined ? command : ([...timeCommand, `--output=${timeOutputPath}`, ...command] as const);
+  const timedCommand =
+    timeCommand === undefined
+      ? command
+      : ([...timeCommand, `--output=${timeOutputPath}`, ...command] as [string, ...string[]]);
+  const spawnedCommand = wrapCommandWithSandboxUser(timedCommand);
   const subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
     cwd: context.cwd,
     detached: process.platform !== 'win32',
-    env: context.env,
+    env: { ...context.env, ...getSandboxUserEnvOverrides() },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
@@ -462,6 +477,12 @@ function resolveTimeCommand(): readonly [string, ...string[]] | undefined {
 
 function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: NodeJS.Signals): void {
   if (subprocess.pid === undefined) return;
+
+  // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes.
+  if (sandboxUserName) {
+    killSandboxUserProcesses();
+    return;
+  }
 
   try {
     if (process.platform === 'win32') {

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -6,9 +6,9 @@ import path from 'node:path';
 import {
   forceRemove,
   getSandboxUserEnvOverrides,
-  isSandboxWrappedCommand,
   killSandboxUserProcesses,
   makeAccessibleToSandboxUser,
+  prependInsideSandboxWrapper,
   sandboxUserName,
   wrapCommandWithSandboxUser,
 } from './sandboxUser.js';
@@ -375,13 +375,14 @@ async function spawnWithInput(
   outputLimitExceeded: boolean;
 }> {
   const timeOutputPath = timeCommand === undefined ? undefined : path.join(context.cwd, '.exercode-time-result');
-  const timedCommand =
+  // `wrapCommandWithSandboxUser` is idempotent, so a command the presets already wrapped is not
+  // nested; `time` is then spliced INSIDE that wrapper so it runs as the sandbox user, never as the
+  // harness user writing `--output` into this sandbox-writable directory.
+  const wrappedCommand = wrapCommandWithSandboxUser(command);
+  const spawnedCommand =
     timeCommand === undefined
-      ? command
-      : ([...timeCommand, `--output=${timeOutputPath}`, ...command] as [string, ...string[]]);
-  // A caller may pass a command the presets already wrapped; wrapping the `time`-prefixed form
-  // again would nest `sudo` inside `sudo` and run the inner one as the unauthorized sandbox user.
-  const spawnedCommand = isSandboxWrappedCommand(command) ? timedCommand : wrapCommandWithSandboxUser(timedCommand);
+      ? wrappedCommand
+      : prependInsideSandboxWrapper(wrappedCommand, [...timeCommand, `--output=${timeOutputPath}`]);
   const subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
     cwd: context.cwd,
     detached: process.platform !== 'win32',

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -15,7 +15,7 @@ import {
   startSandboxTimeoutWatchdog,
   wrapCommandWithSandboxUser,
 } from './sandboxUser.js';
-import { copyWithoutFollowingSymlinks } from './safeFs.js';
+import { copyWithoutFollowingSymlinks, createDirectoryWithoutFollowingSymlinks } from './safeFs.js';
 
 export type PackageManager = 'bun' | 'cargo' | 'go' | 'gradle' | 'maven' | 'npm' | 'pnpm' | 'ruby' | 'uv' | 'yarn';
 type PackageManagerInstallCommand = readonly [string, ...string[]];
@@ -348,14 +348,20 @@ export async function copyPackageManagerProjectFiles(options: {
   projectFilePaths?: readonly string[];
 }): Promise<void> {
   for (const projectFilePath of options.projectFilePaths ?? packageManagerProjectFilePaths[options.packageManager]) {
-    await copyPathIfExists(path.join(options.projectDir, projectFilePath), path.join(options.runDir, projectFilePath));
+    await copyPathIfExists(
+      path.join(options.projectDir, projectFilePath),
+      path.join(options.runDir, projectFilePath),
+      options.runDir
+    );
   }
 }
 
-async function copyPathIfExists(sourcePath: string, destinationPath: string): Promise<void> {
+async function copyPathIfExists(sourcePath: string, destinationPath: string, runDir: string): Promise<void> {
   try {
     // No-follow copy: the destination was seeded from the (sandbox-writable) submission tree, so a
-    // planted symlink there must not redirect this trusted project-file overlay outside runDir.
+    // planted symlink there — at the destination itself or at any directory level of a nested
+    // project file path — must not redirect this trusted project-file overlay outside runDir.
+    await createDirectoryWithoutFollowingSymlinks(runDir, path.dirname(destinationPath));
     await copyWithoutFollowingSymlinks(sourcePath, destinationPath);
   } catch (error) {
     const code =

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -1,4 +1,5 @@
 import childProcess from 'node:child_process';
+import nodeFs from 'node:fs';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -524,13 +525,21 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
 
 async function readTimeResult(timeOutputPath: string): Promise<{ timeSeconds: number; memoryBytes: number }> {
   let content: string;
+  let fileHandle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
-    content = await fs.readFile(timeOutputPath, 'utf8');
+    // `O_NOFOLLOW`: this file lives in the sandbox-writable run directory, so the submission can
+    // replace it with a symlink to a harness-readable file (e.g. the problem's expected outputs)
+    // and have the two numbers at its tail reported back as its own time and memory usage.
+    fileHandle = await fs.open(timeOutputPath, nodeFs.constants.O_RDONLY | nodeFs.constants.O_NOFOLLOW);
+    content = await fileHandle.readFile('utf8');
   } catch (error) {
     const code =
       typeof error === 'object' && error !== null && 'code' in error ? (error as { code: unknown }).code : undefined;
-    if (code !== 'ENOENT') throw error;
+    // ELOOP/EMLINK: the path is a symlink the submission planted, so there is no measurement to read.
+    if (code !== 'ENOENT' && code !== 'ELOOP' && code !== 'EMLINK') throw error;
     return { timeSeconds: 0, memoryBytes: 0 };
+  } finally {
+    await fileHandle?.close();
   }
 
   const match = /(\d+(?:[.,]\d+)?) (\d+)\s*$/.exec(content);

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -576,23 +576,22 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
 }
 
 async function readTimeResult(timeOutputPath: string): Promise<{ timeSeconds: number; memoryBytes: number }> {
-  // The submission owns this directory and can put anything at this path. Anything but a regular
-  // file means there is no measurement to read — and opening a FIFO without `O_NONBLOCK` would
-  // block the harness forever waiting for a writer.
-  try {
-    const stats = await fs.lstat(timeOutputPath);
-    if (!stats.isFile()) return { timeSeconds: 0, memoryBytes: 0 };
-  } catch {
-    return { timeSeconds: 0, memoryBytes: 0 };
-  }
-
+  // The submission owns this directory and can put anything at this path, so decide what was
+  // opened from the handle itself rather than from a prior `lstat` it could race:
+  // - `O_NOFOLLOW` refuses a symlink to a harness-readable file (e.g. the problem's expected
+  //   outputs), which would otherwise report that file's trailing numbers as the submission's own
+  //   time and memory usage;
+  // - `O_NONBLOCK` keeps a planted FIFO from blocking the harness forever waiting for a writer;
+  // - the `fstat` then rejects anything that is not a regular file.
   let content: string;
   let fileHandle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
-    // `O_NOFOLLOW` closes the lstat/open race: the submission can swap in a symlink to a
-    // harness-readable file (e.g. the problem's expected outputs) and have the two numbers at its
-    // tail reported back as its own time and memory usage.
-    fileHandle = await fs.open(timeOutputPath, nodeFs.constants.O_RDONLY | nodeFs.constants.O_NOFOLLOW);
+    fileHandle = await fs.open(
+      timeOutputPath,
+      nodeFs.constants.O_RDONLY | nodeFs.constants.O_NOFOLLOW | nodeFs.constants.O_NONBLOCK
+    );
+    const stats = await fileHandle.stat();
+    if (!stats.isFile()) return { timeSeconds: 0, memoryBytes: 0 };
     content = await fileHandle.readFile('utf8');
   } catch {
     // Whatever the submission swapped in, there is no measurement to report.

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -169,9 +169,13 @@ export async function runCommandInTemporaryPackageManagerProject(
 
     return toPackageManagerCommandRunResult({ elapsedTimeSeconds, options, result });
   } finally {
-    // Daemonized children of the sandboxed command would otherwise outlive the run.
-    if (sandboxUserName) killSandboxUserProcesses();
-    await forceRemove(runDir);
+    try {
+      // Daemonized children of the sandboxed command would otherwise outlive the run.
+      if (sandboxUserName) killSandboxUserProcesses();
+    } finally {
+      // Must run even when the sweep fails closed, or the temporary submission copy leaks.
+      await forceRemove(runDir);
+    }
   }
 }
 
@@ -494,7 +498,14 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
   // so go through sudo with the requested signal only; the callers' existing timers provide the
   // TERM → grace → KILL escalation.
   if (sandboxUserName) {
-    killSandboxUserProcesses([signal === 'SIGKILL' ? 'KILL' : 'TERM']);
+    try {
+      killSandboxUserProcesses([signal === 'SIGKILL' ? 'KILL' : 'TERM']);
+    } catch (error) {
+      // Reached from stream `data` listeners and timer callbacks, where a throw would be an
+      // uncaught exception that kills the harness before any result is printed. The run's `finally`
+      // sweep still fails closed.
+      console.error('failed to signal sandbox processes', error);
+    }
     return;
   }
 

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -10,6 +10,7 @@ import {
   killSandboxUserProcesses,
   makeAccessibleToSandboxUser,
   prependInsideSandboxWrapper,
+  SANDBOX_WATCHDOG_GRACE_SECONDS,
   sandboxUserName,
   startSandboxTimeoutWatchdog,
   wrapCommandWithSandboxUser,
@@ -83,6 +84,8 @@ const packageManagerInstallCommandResolvers = {
 
 const defaultOutputLimitBytes = 50 * 1024 * 1024;
 const killGracePeriodMilliseconds = 1000;
+// Long enough for the watchdog to fire and for the resulting `close` to arrive.
+const watchdogGraceMilliseconds = (SANDBOX_WATCHDOG_GRACE_SECONDS + 2) * 1000;
 const timeCommand = resolveTimeCommand();
 
 /**
@@ -389,28 +392,47 @@ async function spawnWithInput(
     timeCommand === undefined
       ? wrappedCommand
       : prependInsideSandboxWrapper(wrappedCommand, [...timeCommand, `--output=${timeOutputPath}`]);
-  const subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
-    cwd: context.cwd,
-    detached: process.platform !== 'win32',
-    env: { ...context.env, ...getSandboxUserEnvOverrides(context.env) },
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
-  // Deadline enforcement on this path otherwise depends entirely on `killSubprocessGroup`, which
-  // cannot spawn its `sudo` once a submission has exhausted the PID cgroup. This watchdog is
-  // started before the submission can do that, so the deadline holds even then.
+  // Started BEFORE the submission: `killSubprocessGroup` cannot spawn its `sudo` once a submission
+  // has exhausted the PID cgroup, and a submission spawned first could exhaust it before this
+  // watchdog exists. It is the deadline of last resort on this path.
   const watchdog = startSandboxTimeoutWatchdog(context.timeLimitSeconds);
+  let subprocess: childProcess.ChildProcessWithoutNullStreams;
+  try {
+    subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
+      cwd: context.cwd,
+      detached: process.platform !== 'win32',
+      env: { ...context.env, ...getSandboxUserEnvOverrides(context.env) },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    watchdog.cancel();
+    throw error;
+  }
 
   const stdoutChunks: Buffer[] = [];
   const stderrChunks: Buffer[] = [];
   let outputBytes = 0;
   let timedOut = false;
   let outputLimitExceeded = false;
+  // Set when terminating the submission failed (the cleanup `sudo` could not be spawned). The run
+  // then waits for the watchdog to end the submission rather than throwing out of an EventEmitter
+  // callback, which would be an uncaught exception that kills the harness before any cleanup.
+  let killError: Error | undefined;
+  let onKillFailure: (() => void) | undefined;
+  const killOrRecordFailure = (signal: NodeJS.Signals): void => {
+    try {
+      killSubprocessGroup(subprocess, signal);
+    } catch (error) {
+      killError ??= error instanceof Error ? error : new Error(String(error));
+      onKillFailure?.();
+    }
+  };
 
   const appendOutputChunk = (chunks: Buffer[], chunk: Buffer): void => {
     if (outputBytes >= context.outputLimitBytes) {
       if (chunk.byteLength > 0) {
         outputLimitExceeded = true;
-        killSubprocessGroup(subprocess, 'SIGKILL');
+        killOrRecordFailure('SIGKILL');
       }
       return;
     }
@@ -422,35 +444,27 @@ async function spawnWithInput(
 
     if (chunk.byteLength > remainingBytes) {
       outputLimitExceeded = true;
-      killSubprocessGroup(subprocess, 'SIGKILL');
+      killOrRecordFailure('SIGKILL');
     }
   };
 
   subprocess.stdout.on('data', (chunk: Buffer) => appendOutputChunk(stdoutChunks, chunk));
   subprocess.stderr.on('data', (chunk: Buffer) => appendOutputChunk(stderrChunks, chunk));
 
-  // Set by the promise below so a kill failure can settle the run instead of waiting forever for a
-  // `close` that a still-running submission will never emit.
-  let failRun: ((error: Error) => void) | undefined;
-  const killOrFailRun = (signal: NodeJS.Signals): void => {
-    try {
-      killSubprocessGroup(subprocess, signal);
-    } catch (error) {
-      failRun?.(error instanceof Error ? error : new Error(String(error)));
-    }
-  };
-
   const timeout = setTimeout(() => {
     timedOut = true;
-    killOrFailRun('SIGTERM');
+    killOrRecordFailure('SIGTERM');
   }, context.timeLimitSeconds * 1000);
   const killTimeout = setTimeout(
     () => {
-      if (timedOut) killOrFailRun('SIGKILL');
+      if (timedOut) killOrRecordFailure('SIGKILL');
     },
     context.timeLimitSeconds * 1000 + killGracePeriodMilliseconds
   );
   killTimeout.unref();
+  // Bounds the wait after a kill failure: the watchdog force-kills the sandbox user shortly after
+  // the deadline, so `close` should arrive; if even that fails, give up rather than hang.
+  let killFailureTimeout: ReturnType<typeof setTimeout> | undefined;
 
   const { status, signal } = await new Promise<{ status: number | undefined; signal: NodeJS.Signals | undefined }>(
     (resolve, reject) => {
@@ -459,18 +473,22 @@ async function spawnWithInput(
       const failAfterClose = (error: Error): void => {
         if (settled) return;
         pendingError = error;
-        killSubprocessGroup(subprocess, 'SIGKILL');
+        killOrRecordFailure('SIGKILL');
         if (subprocess.pid === undefined) {
           settled = true;
           reject(error);
         }
       };
-      // Terminating the submission failed, so `close` may never arrive: reject now, which lets the
-      // caller's `finally` sweep and temporary-directory cleanup run and surfaces the failure.
-      failRun = (error) => {
-        if (settled) return;
-        settled = true;
-        reject(error);
+      // Terminating the submission failed. Keep waiting: the watchdog (started before the
+      // submission) force-kills the sandbox user shortly after the deadline, so `close` still
+      // arrives and the caller's `finally` sweep and cleanup run. Only if that also fails to end
+      // the submission do we give up, so the run cannot hang indefinitely.
+      onKillFailure = () => {
+        killFailureTimeout ??= setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          reject(killError ?? new Error('failed to terminate the submission'));
+        }, killGracePeriodMilliseconds + watchdogGraceMilliseconds);
       };
       subprocess.on('error', failAfterClose);
       subprocess.stdin.on('error', (error: NodeJS.ErrnoException) => {
@@ -479,8 +497,9 @@ async function spawnWithInput(
       subprocess.on('close', (code, closeSignal) => {
         if (settled) return;
         settled = true;
-        if (pendingError) {
-          reject(pendingError);
+        const error = pendingError ?? killError;
+        if (error) {
+          reject(error);
           return;
         }
         resolve({ status: code ?? undefined, signal: closeSignal ?? undefined });
@@ -490,7 +509,10 @@ async function spawnWithInput(
   ).finally(() => {
     clearTimeout(timeout);
     clearTimeout(killTimeout);
-    watchdog.cancel();
+    if (killFailureTimeout) clearTimeout(killFailureTimeout);
+    // Leave a watchdog whose kill never landed running: cancelling it here would remove the only
+    // remaining mechanism able to stop the submission.
+    if (!killError) watchdog.cancel();
   });
 
   const { timeSeconds, memoryBytes } =

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -84,8 +84,8 @@ const packageManagerInstallCommandResolvers = {
 
 const defaultOutputLimitBytes = 50 * 1024 * 1024;
 const killGracePeriodMilliseconds = 1000;
-// Long enough for the watchdog to fire and for the resulting `close` to arrive.
-const watchdogGraceMilliseconds = (SANDBOX_WATCHDOG_GRACE_SECONDS + 2) * 1000;
+// Added to the watchdog's own deadline so its kill has time to land and `close` to arrive.
+const watchdogSettleMarginMilliseconds = 2000;
 const timeCommand = resolveTimeCommand();
 
 /**
@@ -396,6 +396,7 @@ async function spawnWithInput(
   // has exhausted the PID cgroup, and a submission spawned first could exhaust it before this
   // watchdog exists. It is the deadline of last resort on this path.
   const watchdog = startSandboxTimeoutWatchdog(context.timeLimitSeconds);
+  const watchdogDeadlineAt = Date.now() + (Math.ceil(context.timeLimitSeconds) + SANDBOX_WATCHDOG_GRACE_SECONDS) * 1000;
   let subprocess: childProcess.ChildProcessWithoutNullStreams;
   try {
     subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
@@ -462,9 +463,10 @@ async function spawnWithInput(
     context.timeLimitSeconds * 1000 + killGracePeriodMilliseconds
   );
   killTimeout.unref();
-  // Bounds the wait after a kill failure: the watchdog force-kills the sandbox user shortly after
-  // the deadline, so `close` should arrive; if even that fails, give up rather than hang.
+  // Bounds the wait after a kill failure: the watchdog force-kills the sandbox user at its own
+  // deadline, so `close` should arrive; if even that fails, give up rather than hang.
   let killFailureTimeout: ReturnType<typeof setTimeout> | undefined;
+  let closeObserved = false;
 
   const { status, signal } = await new Promise<{ status: number | undefined; signal: NodeJS.Signals | undefined }>(
     (resolve, reject) => {
@@ -480,15 +482,19 @@ async function spawnWithInput(
         }
       };
       // Terminating the submission failed. Keep waiting: the watchdog (started before the
-      // submission) force-kills the sandbox user shortly after the deadline, so `close` still
-      // arrives and the caller's `finally` sweep and cleanup run. Only if that also fails to end
-      // the submission do we give up, so the run cannot hang indefinitely.
+      // submission) force-kills the sandbox user at its own deadline, so `close` still arrives and
+      // the run reports its real verdict. Give up only once that deadline has passed without the
+      // submission ending, so the run can neither hang nor abandon a still-running submission
+      // while its watchdog could still fire.
       onKillFailure = () => {
-        killFailureTimeout ??= setTimeout(() => {
-          if (settled) return;
-          settled = true;
-          reject(killError ?? new Error('failed to terminate the submission'));
-        }, killGracePeriodMilliseconds + watchdogGraceMilliseconds);
+        killFailureTimeout ??= setTimeout(
+          () => {
+            if (settled) return;
+            settled = true;
+            reject(killError ?? new Error('failed to terminate the submission'));
+          },
+          Math.max(0, watchdogDeadlineAt - Date.now()) + watchdogSettleMarginMilliseconds
+        );
       };
       subprocess.on('error', failAfterClose);
       subprocess.stdin.on('error', (error: NodeJS.ErrnoException) => {
@@ -497,9 +503,12 @@ async function spawnWithInput(
       subprocess.on('close', (code, closeSignal) => {
         if (settled) return;
         settled = true;
-        const error = pendingError ?? killError;
-        if (error) {
-          reject(error);
+        // The submission ended, so the watchdog has nothing left to kill and must not outlive this
+        // run. A kill that failed once but succeeded on retry (or was superseded by the watchdog)
+        // is not an error: the timeout/output-limit verdict below is the correct one to report.
+        closeObserved = true;
+        if (pendingError) {
+          reject(pendingError);
           return;
         }
         resolve({ status: code ?? undefined, signal: closeSignal ?? undefined });
@@ -510,9 +519,9 @@ async function spawnWithInput(
     clearTimeout(timeout);
     clearTimeout(killTimeout);
     if (killFailureTimeout) clearTimeout(killFailureTimeout);
-    // Leave a watchdog whose kill never landed running: cancelling it here would remove the only
-    // remaining mechanism able to stop the submission.
-    if (!killError) watchdog.cancel();
+    // Cancel unless the submission is still running after a failed kill: the watchdog is then the
+    // only remaining mechanism able to stop it, and cancelling would leave it running unchecked.
+    if (closeObserved || !killError) watchdog.cancel();
   });
 
   const { timeSeconds, memoryBytes } =
@@ -545,8 +554,9 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
   // so go through sudo with the requested signal only; the callers' existing timers provide the
   // TERM → grace → KILL escalation.
   // Throws when the cleanup `sudo` cannot even be spawned (a submission can exhaust the PID
-  // cgroup). Callers must catch it — `killOrFailRun` settles the run so it cannot hang waiting for
-  // a `close` that a still-running submission will never emit.
+  // cgroup). Only `killOrRecordFailure` may call this: it records the failure and lets the
+  // watchdog (or, past its deadline, a bounded timer) settle the run instead of letting the throw
+  // escape an EventEmitter callback.
   if (sandboxUserName) {
     killSandboxUserProcesses([signal === 'SIGKILL' ? 'KILL' : 'TERM']);
     return;

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -164,6 +164,8 @@ export async function runCommandInTemporaryPackageManagerProject(
 
     return toPackageManagerCommandRunResult({ elapsedTimeSeconds, options, result });
   } finally {
+    // Daemonized children of the sandboxed command would otherwise outlive the run.
+    if (sandboxUserName) killSandboxUserProcesses();
     await forceRemove(runDir);
   }
 }
@@ -374,7 +376,7 @@ async function spawnWithInput(
   const subprocess = childProcess.spawn(spawnedCommand[0], spawnedCommand.slice(1), {
     cwd: context.cwd,
     detached: process.platform !== 'win32',
-    env: { ...context.env, ...getSandboxUserEnvOverrides() },
+    env: { ...context.env, ...getSandboxUserEnvOverrides(context.env) },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
@@ -478,9 +480,11 @@ function resolveTimeCommand(): readonly [string, ...string[]] | undefined {
 function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: NodeJS.Signals): void {
   if (subprocess.pid === undefined) return;
 
-  // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes.
+  // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes,
+  // so go through sudo with the requested signal only; the callers' existing timers provide the
+  // TERM → grace → KILL escalation.
   if (sandboxUserName) {
-    killSandboxUserProcesses();
+    killSandboxUserProcesses([signal === 'SIGKILL' ? 'KILL' : 'TERM']);
     return;
   }
 

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -11,6 +11,7 @@ import {
   makeAccessibleToSandboxUser,
   prependInsideSandboxWrapper,
   sandboxUserName,
+  startSandboxTimeoutWatchdog,
   wrapCommandWithSandboxUser,
 } from './sandboxUser.js';
 import { copyWithoutFollowingSymlinks } from './safeFs.js';
@@ -394,6 +395,10 @@ async function spawnWithInput(
     env: { ...context.env, ...getSandboxUserEnvOverrides(context.env) },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+  // Deadline enforcement on this path otherwise depends entirely on `killSubprocessGroup`, which
+  // cannot spawn its `sudo` once a submission has exhausted the PID cgroup. This watchdog is
+  // started before the submission can do that, so the deadline holds even then.
+  const watchdog = startSandboxTimeoutWatchdog(context.timeLimitSeconds);
 
   const stdoutChunks: Buffer[] = [];
   const stderrChunks: Buffer[] = [];
@@ -424,13 +429,24 @@ async function spawnWithInput(
   subprocess.stdout.on('data', (chunk: Buffer) => appendOutputChunk(stdoutChunks, chunk));
   subprocess.stderr.on('data', (chunk: Buffer) => appendOutputChunk(stderrChunks, chunk));
 
+  // Set by the promise below so a kill failure can settle the run instead of waiting forever for a
+  // `close` that a still-running submission will never emit.
+  let failRun: ((error: Error) => void) | undefined;
+  const killOrFailRun = (signal: NodeJS.Signals): void => {
+    try {
+      killSubprocessGroup(subprocess, signal);
+    } catch (error) {
+      failRun?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  };
+
   const timeout = setTimeout(() => {
     timedOut = true;
-    killSubprocessGroup(subprocess, 'SIGTERM');
+    killOrFailRun('SIGTERM');
   }, context.timeLimitSeconds * 1000);
   const killTimeout = setTimeout(
     () => {
-      if (timedOut) killSubprocessGroup(subprocess, 'SIGKILL');
+      if (timedOut) killOrFailRun('SIGKILL');
     },
     context.timeLimitSeconds * 1000 + killGracePeriodMilliseconds
   );
@@ -448,6 +464,13 @@ async function spawnWithInput(
           settled = true;
           reject(error);
         }
+      };
+      // Terminating the submission failed, so `close` may never arrive: reject now, which lets the
+      // caller's `finally` sweep and temporary-directory cleanup run and surfaces the failure.
+      failRun = (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
       };
       subprocess.on('error', failAfterClose);
       subprocess.stdin.on('error', (error: NodeJS.ErrnoException) => {
@@ -467,6 +490,7 @@ async function spawnWithInput(
   ).finally(() => {
     clearTimeout(timeout);
     clearTimeout(killTimeout);
+    watchdog.cancel();
   });
 
   const { timeSeconds, memoryBytes } =
@@ -498,15 +522,11 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
   // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes,
   // so go through sudo with the requested signal only; the callers' existing timers provide the
   // TERM → grace → KILL escalation.
+  // Throws when the cleanup `sudo` cannot even be spawned (a submission can exhaust the PID
+  // cgroup). Callers must catch it — `killOrFailRun` settles the run so it cannot hang waiting for
+  // a `close` that a still-running submission will never emit.
   if (sandboxUserName) {
-    try {
-      killSandboxUserProcesses([signal === 'SIGKILL' ? 'KILL' : 'TERM']);
-    } catch (error) {
-      // Reached from stream `data` listeners and timer callbacks, where a throw would be an
-      // uncaught exception that kills the harness before any result is printed. The run's `finally`
-      // sweep still fails closed.
-      console.error('failed to signal sandbox processes', error);
-    }
+    killSandboxUserProcesses([signal === 'SIGKILL' ? 'KILL' : 'TERM']);
     return;
   }
 
@@ -524,19 +544,26 @@ function killSubprocessGroup(subprocess: childProcess.ChildProcess, signal: Node
 }
 
 async function readTimeResult(timeOutputPath: string): Promise<{ timeSeconds: number; memoryBytes: number }> {
+  // The submission owns this directory and can put anything at this path. Anything but a regular
+  // file means there is no measurement to read — and opening a FIFO without `O_NONBLOCK` would
+  // block the harness forever waiting for a writer.
+  try {
+    const stats = await fs.lstat(timeOutputPath);
+    if (!stats.isFile()) return { timeSeconds: 0, memoryBytes: 0 };
+  } catch {
+    return { timeSeconds: 0, memoryBytes: 0 };
+  }
+
   let content: string;
   let fileHandle: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
-    // `O_NOFOLLOW`: this file lives in the sandbox-writable run directory, so the submission can
-    // replace it with a symlink to a harness-readable file (e.g. the problem's expected outputs)
-    // and have the two numbers at its tail reported back as its own time and memory usage.
+    // `O_NOFOLLOW` closes the lstat/open race: the submission can swap in a symlink to a
+    // harness-readable file (e.g. the problem's expected outputs) and have the two numbers at its
+    // tail reported back as its own time and memory usage.
     fileHandle = await fs.open(timeOutputPath, nodeFs.constants.O_RDONLY | nodeFs.constants.O_NOFOLLOW);
     content = await fileHandle.readFile('utf8');
-  } catch (error) {
-    const code =
-      typeof error === 'object' && error !== null && 'code' in error ? (error as { code: unknown }).code : undefined;
-    // ELOOP/EMLINK: the path is a symlink the submission planted, so there is no measurement to read.
-    if (code !== 'ENOENT' && code !== 'ELOOP' && code !== 'EMLINK') throw error;
+  } catch {
+    // Whatever the submission swapped in, there is no measurement to report.
     return { timeSeconds: 0, memoryBytes: 0 };
   } finally {
     await fileHandle?.close();

--- a/src/helpers/runCustomRunner.ts
+++ b/src/helpers/runCustomRunner.ts
@@ -1,0 +1,16 @@
+import { killSandboxUserProcesses, sandboxUserName } from './sandboxUser.js';
+
+/**
+ * Run a problem-supplied `runCommand` handler, then terminate every sandbox-user process it left
+ * behind. A submission can daemonize and close its inherited streams so the handler returns while
+ * its child keeps running; that child could otherwise modify the working directory while the
+ * harness reads outputs, or survive into the next test case or request. The built-in run paths
+ * sweep the same way in their own `finally`.
+ */
+export async function runCustomRunner<T>(run: () => Promise<T> | T): Promise<T> {
+  try {
+    return await run();
+  } finally {
+    if (sandboxUserName) killSandboxUserProcesses();
+  }
+}

--- a/src/helpers/safeFs.ts
+++ b/src/helpers/safeFs.ts
@@ -14,8 +14,6 @@ import path from 'node:path';
 export async function copyWithoutFollowingSymlinks(source: string, destination: string): Promise<void> {
   const sourceStats = await fs.promises.lstat(source);
 
-  const existingDestinationStats = await lstatOrUndefined(destination);
-
   if (sourceStats.isSymbolicLink()) {
     await removeExistingEntry(destination);
     await fs.promises.symlink(await fs.promises.readlink(source), destination);
@@ -25,6 +23,7 @@ export async function copyWithoutFollowingSymlinks(source: string, destination: 
   if (sourceStats.isDirectory()) {
     // A pre-existing symlink (or file) at the destination is removed so the merge target is a real
     // directory the harness owns, not something the submission redirected.
+    const existingDestinationStats = await lstatOrUndefined(destination);
     if (!existingDestinationStats?.isDirectory()) await removeExistingEntry(destination);
     await fs.promises.mkdir(destination, { recursive: true });
     for (const entry of await fs.promises.readdir(source)) {

--- a/src/helpers/safeFs.ts
+++ b/src/helpers/safeFs.ts
@@ -48,7 +48,7 @@ export async function copyWithoutFollowingSymlinks(source: string, destination: 
  */
 export async function createDirectoryWithoutFollowingSymlinks(root: string, directory: string): Promise<void> {
   const relativePath = path.relative(root, directory);
-  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+  if (!isContainedPath(root, directory)) {
     throw new Error(`directory must be inside root: ${directory} is not inside ${root}`);
   }
 

--- a/src/helpers/safeFs.ts
+++ b/src/helpers/safeFs.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Recursively copy `source` into `destination` without ever following a symlink that already
+ * exists at a destination path. A sandboxed submission (running as a different OS user) can plant
+ * such a symlink to redirect this trusted-user write outside its working directory, so every
+ * pre-existing destination entry is lstat'd and unlinked (never followed) before being written.
+ * Symlinks in the SOURCE are recreated as symlinks; their targets are never read.
+ *
+ * Merges into an existing destination directory (like `fs.cp(..., { recursive: true })`), but a
+ * plain `fs.cp` follows destination symlinks nested inside directories, which this avoids.
+ */
+export async function copyWithoutFollowingSymlinks(source: string, destination: string): Promise<void> {
+  const sourceStats = await fs.promises.lstat(source);
+
+  if (sourceStats.isSymbolicLink()) {
+    await removeExistingEntry(destination);
+    await fs.promises.symlink(await fs.promises.readlink(source), destination);
+    return;
+  }
+
+  if (sourceStats.isDirectory()) {
+    const destinationStats = await lstatOrUndefined(destination);
+    // A pre-existing symlink (or file) at the destination is removed so the merge target is a real
+    // directory the harness owns, not something the submission redirected.
+    if (!destinationStats?.isDirectory()) await removeExistingEntry(destination);
+    await fs.promises.mkdir(destination, { recursive: true });
+    for (const entry of await fs.promises.readdir(source)) {
+      await copyWithoutFollowingSymlinks(path.join(source, entry), path.join(destination, entry));
+    }
+    return;
+  }
+
+  await removeExistingEntry(destination);
+  await fs.promises.copyFile(source, destination);
+}
+
+// `fs.rm` unlinks a symlink itself rather than following it, and removes files/directories otherwise.
+async function removeExistingEntry(target: string): Promise<void> {
+  await fs.promises.rm(target, { force: true, recursive: true });
+}
+
+async function lstatOrUndefined(target: string): Promise<fs.Stats | undefined> {
+  try {
+    return await fs.promises.lstat(target);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/helpers/safeFs.ts
+++ b/src/helpers/safeFs.ts
@@ -14,13 +14,7 @@ import path from 'node:path';
 export async function copyWithoutFollowingSymlinks(source: string, destination: string): Promise<void> {
   const sourceStats = await fs.promises.lstat(source);
 
-  // Like `fs.cp`, refuse to overwrite a real directory with a non-directory instead of deleting
-  // it: `copyTestCaseFileInput` passes the working directory itself as the destination root, and a
-  // file-typed source must never wipe it.
   const existingDestinationStats = await lstatOrUndefined(destination);
-  if (!sourceStats.isDirectory() && existingDestinationStats?.isDirectory()) {
-    throw new Error(`cannot overwrite directory '${destination}' with non-directory '${source}'`);
-  }
 
   if (sourceStats.isSymbolicLink()) {
     await removeExistingEntry(destination);

--- a/src/helpers/safeFs.ts
+++ b/src/helpers/safeFs.ts
@@ -14,6 +14,14 @@ import path from 'node:path';
 export async function copyWithoutFollowingSymlinks(source: string, destination: string): Promise<void> {
   const sourceStats = await fs.promises.lstat(source);
 
+  // Like `fs.cp`, refuse to overwrite a real directory with a non-directory instead of deleting
+  // it: `copyTestCaseFileInput` passes the working directory itself as the destination root, and a
+  // file-typed source must never wipe it.
+  const existingDestinationStats = await lstatOrUndefined(destination);
+  if (!sourceStats.isDirectory() && existingDestinationStats?.isDirectory()) {
+    throw new Error(`cannot overwrite directory '${destination}' with non-directory '${source}'`);
+  }
+
   if (sourceStats.isSymbolicLink()) {
     await removeExistingEntry(destination);
     await fs.promises.symlink(await fs.promises.readlink(source), destination);
@@ -21,10 +29,9 @@ export async function copyWithoutFollowingSymlinks(source: string, destination: 
   }
 
   if (sourceStats.isDirectory()) {
-    const destinationStats = await lstatOrUndefined(destination);
     // A pre-existing symlink (or file) at the destination is removed so the merge target is a real
     // directory the harness owns, not something the submission redirected.
-    if (!destinationStats?.isDirectory()) await removeExistingEntry(destination);
+    if (!existingDestinationStats?.isDirectory()) await removeExistingEntry(destination);
     await fs.promises.mkdir(destination, { recursive: true });
     for (const entry of await fs.promises.readdir(source)) {
       await copyWithoutFollowingSymlinks(path.join(source, entry), path.join(destination, entry));

--- a/src/helpers/safeFs.ts
+++ b/src/helpers/safeFs.ts
@@ -68,6 +68,18 @@ async function removeExistingEntry(target: string): Promise<void> {
   await forceRemove(target);
 }
 
+/**
+ * Write `data` to `filePath` without following a symlink already there. `fs.writeFile` follows one,
+ * so a sandboxed submission could point a file the harness is about to write (a generated project
+ * file, a fixture) at something only the harness can reach and have it overwritten. Trusted
+ * callbacks that create files inside a submission directory must use this instead.
+ */
+export async function writeFileWithoutFollowingSymlinks(filePath: string, data: string | Uint8Array): Promise<void> {
+  await removeExistingEntry(filePath);
+  // `wx` fails rather than following a symlink planted between the removal and the write.
+  await fs.promises.writeFile(filePath, data, { flag: 'wx' });
+}
+
 /** Whether `realTargetPath` is `realDirectoryPath` itself or below it. Both must be realpaths. */
 export function isContainedPath(realDirectoryPath: string, realTargetPath: string): boolean {
   const relativePath = path.relative(realDirectoryPath, realTargetPath);

--- a/src/helpers/safeFs.ts
+++ b/src/helpers/safeFs.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { forceRemove } from './sandboxUser.js';
+
 /**
  * Recursively copy `source` into `destination` without ever following a symlink that already
  * exists at a destination path. A sandboxed submission (running as a different OS user) can plant
@@ -13,6 +15,8 @@ import path from 'node:path';
  */
 export async function copyWithoutFollowingSymlinks(source: string, destination: string): Promise<void> {
   const sourceStats = await fs.promises.lstat(source);
+  // `fs.cp` creates missing destination parents; `copyFile`/`symlink` would fail with ENOENT.
+  await fs.promises.mkdir(path.dirname(destination), { recursive: true });
 
   if (sourceStats.isSymbolicLink()) {
     await removeExistingEntry(destination);
@@ -36,9 +40,10 @@ export async function copyWithoutFollowingSymlinks(source: string, destination: 
   await fs.promises.copyFile(source, destination);
 }
 
-// `fs.rm` unlinks a symlink itself rather than following it, and removes files/directories otherwise.
+// `fs.rm` unlinks a symlink itself rather than following it, and removes files/directories
+// otherwise; `forceRemove` adds the retry for entries a sandboxed submission left unreadable.
 async function removeExistingEntry(target: string): Promise<void> {
-  await fs.promises.rm(target, { force: true, recursive: true });
+  await forceRemove(target);
 }
 
 async function lstatOrUndefined(target: string): Promise<fs.Stats | undefined> {

--- a/src/helpers/safeFs.ts
+++ b/src/helpers/safeFs.ts
@@ -15,8 +15,6 @@ import { forceRemove } from './sandboxUser.js';
  */
 export async function copyWithoutFollowingSymlinks(source: string, destination: string): Promise<void> {
   const sourceStats = await fs.promises.lstat(source);
-  // `fs.cp` creates missing destination parents; `copyFile`/`symlink` would fail with ENOENT.
-  await fs.promises.mkdir(path.dirname(destination), { recursive: true });
 
   if (sourceStats.isSymbolicLink()) {
     await removeExistingEntry(destination);
@@ -40,10 +38,41 @@ export async function copyWithoutFollowingSymlinks(source: string, destination: 
   await fs.promises.copyFile(source, destination);
 }
 
+/**
+ * Create `directory` and the missing levels between it and `root`, replacing anything that is not
+ * already a real directory. `fs.mkdir(..., { recursive: true })` follows a symlink it finds on the
+ * way, which a submission can plant to place a trusted-user write outside the tree; this walks the
+ * levels one at a time instead. Only levels BELOW `root` are inspected, so an unrelated symlink
+ * above the caller's tree (`/tmp` on macOS, for instance) is never touched. `root` must already be
+ * a directory the harness trusts, and `directory` must be inside it.
+ */
+export async function createDirectoryWithoutFollowingSymlinks(root: string, directory: string): Promise<void> {
+  const relativePath = path.relative(root, directory);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`directory must be inside root: ${directory} is not inside ${root}`);
+  }
+
+  let currentPath = root;
+  for (const level of relativePath.split(path.sep).filter(Boolean)) {
+    currentPath = path.join(currentPath, level);
+    const stats = await lstatOrUndefined(currentPath);
+    if (stats?.isDirectory()) continue;
+    if (stats) await removeExistingEntry(currentPath);
+    await fs.promises.mkdir(currentPath);
+  }
+}
+
 // `fs.rm` unlinks a symlink itself rather than following it, and removes files/directories
 // otherwise; `forceRemove` adds the retry for entries a sandboxed submission left unreadable.
 async function removeExistingEntry(target: string): Promise<void> {
   await forceRemove(target);
+}
+
+/** Whether `realTargetPath` is `realDirectoryPath` itself or below it. Both must be realpaths. */
+export function isContainedPath(realDirectoryPath: string, realTargetPath: string): boolean {
+  const relativePath = path.relative(realDirectoryPath, realTargetPath);
+  // A bare `..`-prefix test would also reject an in-directory name like `..result`.
+  return relativePath !== '..' && !relativePath.startsWith(`..${path.sep}`) && !path.isAbsolute(relativePath);
 }
 
 async function lstatOrUndefined(target: string): Promise<fs.Stats | undefined> {

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -71,17 +71,14 @@ export function wrapCommandWithSandboxUser(command: readonly [string, ...string[
   if (!sandboxUserName) return [...command];
   // Idempotent; see {@link isSandboxWrappedCommand}.
   if (isSandboxWrappedCommand(command)) return [...command];
-  return [
-    SUDO_PATH,
-    '--preserve-env',
-    '-u',
-    sandboxUserName,
-    '--',
-    'sh',
-    '-c',
-    'umask 0; if [ -n "$SANDBOX_LD_LIBRARY_PATH" ]; then export LD_LIBRARY_PATH="$SANDBOX_LD_LIBRARY_PATH"; fi; exec "$0" "$@"',
-    ...command,
-  ];
+  return [...buildSandboxWrapperPrefix(sandboxUserName), ...command];
+}
+
+const SANDBOX_WRAPPER_SCRIPT =
+  'umask 0; if [ -n "$SANDBOX_LD_LIBRARY_PATH" ]; then export LD_LIBRARY_PATH="$SANDBOX_LD_LIBRARY_PATH"; fi; exec "$0" "$@"';
+
+function buildSandboxWrapperPrefix(user: string): [string, ...string[]] {
+  return [SUDO_PATH, '--preserve-env', '-u', user, '--', 'sh', '-c', SANDBOX_WRAPPER_SCRIPT];
 }
 
 /**
@@ -89,9 +86,31 @@ export function wrapCommandWithSandboxUser(command: readonly [string, ...string[
  * custom runners a wrapped command, and a runner may forward it to another helper that wraps too;
  * a nested wrapper's inner `sudo` would run AS the sandbox user, which sudoers does not authorize,
  * so every test case of such a problem would fail only under delegation.
+ *
+ * Matches the wrapper prefix exactly rather than looking for `sudo` anywhere: a submission-derived
+ * command could otherwise carry a literal `/usr/bin/sudo` argument and skip wrapping entirely,
+ * which would run the submission as the trusted harness user.
  */
 export function isSandboxWrappedCommand(command: readonly string[]): boolean {
-  return command.includes(SUDO_PATH);
+  if (!sandboxUserName) return false;
+  const prefix = buildSandboxWrapperPrefix(sandboxUserName);
+  return prefix.every((argument, index) => command[index] === argument);
+}
+
+/**
+ * Insert `innerPrefix` (e.g. a `time` measurement prefix) so that it runs INSIDE the sandbox
+ * wrapper when `command` is wrapped, and simply in front otherwise. Prefixing a wrapped command
+ * from the outside would run `innerPrefix` as the trusted harness user while its arguments (such
+ * as an output path) point into a sandbox-writable directory, where a submission can plant a
+ * symlink and have the harness truncate an arbitrary file it owns.
+ */
+export function prependInsideSandboxWrapper(
+  command: readonly [string, ...string[]],
+  innerPrefix: readonly string[]
+): [string, ...string[]] {
+  if (!isSandboxWrappedCommand(command)) return [...innerPrefix, ...command] as [string, ...string[]];
+  const prefixLength = buildSandboxWrapperPrefix(sandboxUserName as string).length;
+  return [...command.slice(0, prefixLength), ...innerPrefix, ...command.slice(prefixLength)] as [string, ...string[]];
 }
 
 /**

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -170,6 +170,12 @@ export function relaxPermissionsAsSandboxUser(targetPath: string): void {
   runAsSandboxUser(['chmod', '-R', 'a+rwX', targetPath]);
 }
 
+/**
+ * How long after a command's own deadline {@link startSandboxTimeoutWatchdog} force-kills the
+ * sandbox user. Callers waiting for the watchdog to end a submission must wait at least this long.
+ */
+export const SANDBOX_WATCHDOG_GRACE_SECONDS = 5;
+
 /** Cancels a {@link startSandboxTimeoutWatchdog}; `fired` reports whether its deadline elapsed. */
 export interface SandboxTimeoutWatchdog {
   cancel(): void;
@@ -189,7 +195,7 @@ export interface SandboxTimeoutWatchdog {
 export function startSandboxTimeoutWatchdog(timeoutSeconds: number): SandboxTimeoutWatchdog {
   if (!sandboxUserName) return { cancel: () => {}, fired: () => false };
 
-  const deadlineSeconds = Math.ceil(timeoutSeconds) + 5;
+  const deadlineSeconds = Math.ceil(timeoutSeconds) + SANDBOX_WATCHDOG_GRACE_SECONDS;
   const watchdog = child_process.spawn(
     '/bin/sh',
     ['-c', `${SLEEP_PATH} ${deadlineSeconds}; ${SUDO_PATH} -u "$1" pkill -KILL -u "$1"`, 'sh', sandboxUserName],

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -21,6 +21,9 @@ import os from 'node:os';
  *   stderr into stdout and CRLF-mangle output when the harness happens to run from a terminal):
  *   e.g. `Defaults:<harness> !env_reset, !env_delete, !env_check, !secure_path, !use_pty` plus
  *   `<harness> ALL=(<sandbox>) NOPASSWD:SETENV: ALL`.
+ * - Variables meant for the submitted program rather than for the harness must be passed under
+ *   {@link SANDBOX_ENV_PREFIX}; problem-utils strips that prefix when it builds a submission's
+ *   environment.
  * - The sandbox user's home directory must exist at `/home/<sandbox user>` and be writable. It is
  *   shared across sequential requests, so the server is responsible for resetting whatever
  *   cross-request persistence there matters to it.
@@ -121,11 +124,32 @@ export function prependInsideSandboxWrapper(
  */
 export function getSandboxUserEnvOverrides(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   if (!sandboxUserName) return {};
-  const ldLibraryPath = env?.LD_LIBRARY_PATH ?? process.env.LD_LIBRARY_PATH;
+  const sourceEnv = env ?? process.env;
+  const ldLibraryPath = sourceEnv.LD_LIBRARY_PATH ?? process.env.LD_LIBRARY_PATH;
   return {
     HOME: `/home/${sandboxUserName}`,
     ...(ldLibraryPath && { SANDBOX_LD_LIBRARY_PATH: ldLibraryPath }),
+    ...unwrapSubmissionOnlyEnv(sourceEnv),
   };
+}
+
+/**
+ * Prefix under which a delegating judge server passes variables that belong to the submitted
+ * program alone. Applying a request's variables to the harness itself would let a submission point
+ * e.g. `PATH` or `NODE_OPTIONS` at its own files and get code executed as the trusted harness user,
+ * so the server prefixes them and problem-utils strips the prefix back off here, where the
+ * environment of a sandboxed submission is built.
+ */
+export const SANDBOX_ENV_PREFIX = 'SANDBOX_ENV_';
+
+function unwrapSubmissionOnlyEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const unwrapped: NodeJS.ProcessEnv = {};
+  for (const [name, value] of Object.entries(env)) {
+    if (!name.startsWith(SANDBOX_ENV_PREFIX)) continue;
+    const unwrappedName = name.slice(SANDBOX_ENV_PREFIX.length);
+    if (unwrappedName) unwrapped[unwrappedName] = value;
+  }
+  return unwrapped;
 }
 
 /**

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -10,11 +10,23 @@ import fs from 'node:fs';
  * submissions while the submissions themselves run under the sandbox user. When the variable is
  * absent or empty (local development, course authoring, or an all-sandbox judge run), commands run
  * as the current user like before.
+ *
+ * Contract for the delegating judge server:
+ * - The harness process environment is forwarded verbatim to sandboxed submissions (sudo runs with
+ *   `--preserve-env`), so it must not contain secrets beyond what submissions may see.
+ * - sudoers must let the harness user run arbitrary commands as the sandbox user without a
+ *   password and pass the environment through (e.g. `Defaults:<harness> !env_reset, !env_delete,
+ *   !env_check, !secure_path` plus `<harness> ALL=(<sandbox>) NOPASSWD:SETENV: ALL`).
+ * - The sandbox user's home directory must exist at `/home/<sandbox user>` and be writable.
  */
 export const SANDBOX_USER_ENV_NAME = 'EXERCODE_SANDBOX_USER';
 
-// Absolute path so a submission-controlled `PATH` cannot redirect the privileged `sudo`.
+// Absolute paths so a submission-influenced `PATH` cannot redirect binaries that the trusted
+// harness user executes (`sudo` is also setuid and must be the real one).
 const SUDO_PATH = '/usr/bin/sudo';
+const CHMOD_PATH = '/bin/chmod';
+// Minimal environment for trusted helper processes; never forward the harness environment to them.
+const MINIMAL_ENV = { PATH: '/usr/local/bin:/usr/bin:/bin' } as const;
 
 export const sandboxUserName = process.env[SANDBOX_USER_ENV_NAME] || undefined;
 
@@ -42,13 +54,16 @@ export function wrapCommandWithSandboxUser(command: readonly [string, ...string[
 
 /**
  * Environment overrides for sandboxed processes: a writable home and the `LD_LIBRARY_PATH`
- * smuggled past the setuid `sudo` exec (see {@link wrapCommandWithSandboxUser}).
+ * smuggled past the setuid `sudo` exec (see {@link wrapCommandWithSandboxUser}). Pass the
+ * environment the command will actually run with so a caller-supplied `LD_LIBRARY_PATH` survives
+ * the exec; the harness's own value is only the fallback.
  */
-export function getSandboxUserEnvOverrides(): NodeJS.ProcessEnv {
+export function getSandboxUserEnvOverrides(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   if (!sandboxUserName) return {};
+  const ldLibraryPath = env?.LD_LIBRARY_PATH ?? process.env.LD_LIBRARY_PATH;
   return {
     HOME: `/home/${sandboxUserName}`,
-    ...(process.env.LD_LIBRARY_PATH && { SANDBOX_LD_LIBRARY_PATH: process.env.LD_LIBRARY_PATH }),
+    ...(ldLibraryPath && { SANDBOX_LD_LIBRARY_PATH: ldLibraryPath }),
   };
 }
 
@@ -59,43 +74,82 @@ export function getSandboxUserEnvOverrides(): NodeJS.ProcessEnv {
 export function makeAccessibleToSandboxUser(targetPath: string): void {
   if (!sandboxUserName) return;
   // Files owned by the sandbox user fail to chmod but are already world-writable (umask 0).
-  child_process.spawnSync('chmod', ['-R', 'a+rwX', targetPath]);
+  child_process.spawnSync(CHMOD_PATH, ['-R', 'a+rwX', targetPath], { env: MINIMAL_ENV });
 }
 
 /**
- * Kill all processes of the sandbox user. The harness user cannot signal another user's processes
- * (nor the root-owned `sudo` wrapper), so this goes through sudo. Killing every sandbox process is
- * safe because the judge server handles one request at a time. SIGTERM is followed by SIGKILL so a
- * submission that traps SIGTERM cannot survive cleanup.
+ * Kill the sandbox user's processes with the given signals. The harness user cannot signal another
+ * user's processes (nor the root-owned `sudo` wrapper), so this goes through sudo. Killing every
+ * sandbox process is safe because the judge server handles one request at a time. The default
+ * sends SIGTERM immediately followed by SIGKILL (final cleanup); callers that want a grace period
+ * send `['TERM']`, wait, and then send `['KILL']`.
  */
-export function killSandboxUserProcesses(): void {
+export function killSandboxUserProcesses(signals: readonly ('TERM' | 'KILL')[] = ['TERM', 'KILL']): void {
   if (!sandboxUserName) return;
-  // Two direct calls instead of one `sh -c 'pkill ...; pkill ...'`: the wrapping shell would run as
-  // the sandbox user too, so the first pkill would kill it before the second ran. Each `pkill`
-  // exits with 1 when no process matches, so ignore the exit status.
-  for (const signal of ['-TERM', '-KILL']) {
-    child_process.spawnSync(SUDO_PATH, ['-u', sandboxUserName, 'pkill', signal, '-u', sandboxUserName], {
-      // The harness environment must not be passed: sudoers forwards it verbatim, and after sudo
-      // drops privileges the helper's `/proc/<pid>/environ` becomes readable by every other
-      // sandbox process.
-      env: { PATH: '/usr/local/bin:/usr/bin:/bin' },
-    });
+  // One direct call per signal instead of one `sh -c 'pkill ...; pkill ...'`: the wrapping shell
+  // would run as the sandbox user too, so the first pkill would kill it before the second ran.
+  // Each `pkill` exits with 1 when no process matches, so ignore the exit status.
+  for (const signal of signals) {
+    runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName]);
   }
 }
 
 /**
+ * Let the sandbox user reopen the permissions of its own files under the given path, for
+ * harness-side traversal/cleanup of trees where a sandboxed process restricted permissions
+ * (some tools chmod their outputs regardless of umask).
+ */
+export function relaxPermissionsAsSandboxUser(targetPath: string): void {
+  if (!sandboxUserName) return;
+  runAsSandboxUser(['chmod', '-R', 'a+rwX', targetPath]);
+}
+
+/**
+ * Start a harness-owned watchdog that force-kills every sandbox process after the given deadline,
+ * and return a function that cancels it. A sandboxed submission can signal its own `timeout`
+ * supervisor (same UID), and a synchronous spawn blocks the harness's event loop, so without this
+ * external deadline a submission could run until the outer judge-server limit. The watchdog's
+ * `sh`/`sleep` run as the harness user, out of the submission's reach; killing the watchdog's
+ * process group cancels it before it spawns sudo.
+ */
+export function startSandboxTimeoutWatchdog(timeoutSeconds: number): () => void {
+  if (!sandboxUserName) return () => {};
+  const deadlineSeconds = Math.ceil(timeoutSeconds) + 5;
+  const watchdog = child_process.spawn(
+    '/bin/sh',
+    ['-c', `sleep ${deadlineSeconds}; ${SUDO_PATH} -u "$1" pkill -KILL -u "$1"`, 'sh', sandboxUserName],
+    { detached: true, stdio: 'ignore', env: MINIMAL_ENV }
+  );
+  watchdog.unref();
+  return () => {
+    if (watchdog.pid === undefined) return;
+    try {
+      process.kill(-watchdog.pid, 'SIGKILL');
+    } catch {
+      // The watchdog already fired and exited.
+    }
+  };
+}
+
+/**
+ * Run a helper as the sandbox user with a minimal environment. The harness environment must not be
+ * passed: sudoers forwards it verbatim, and after sudo drops privileges the helper's
+ * `/proc/<pid>/environ` becomes readable by every other sandbox process.
+ */
+function runAsSandboxUser(command: [string, ...string[]]): void {
+  child_process.spawnSync(SUDO_PATH, ['-u', sandboxUserName as string, ...command], { env: MINIMAL_ENV });
+}
+
+/**
  * `fs.rm`-like removal with a fallback for trees holding sandbox-user-owned entries whose
- * permissions block deletion (some tools chmod their outputs regardless of umask): let the sandbox
- * user reopen its own files first, then retry.
+ * permissions block deletion: let the sandbox user reopen its own files first, then retry.
  */
 export async function forceRemove(targetPath: string): Promise<void> {
   try {
     await fs.promises.rm(targetPath, { force: true, recursive: true });
   } catch (error) {
     if (!sandboxUserName) throw error;
-    child_process.spawnSync(SUDO_PATH, ['-u', sandboxUserName, 'chmod', '-R', 'a+rwX', targetPath], {
-      env: { PATH: '/usr/local/bin:/usr/bin:/bin' },
-    });
+    relaxPermissionsAsSandboxUser(targetPath);
     await fs.promises.rm(targetPath, { force: true, recursive: true });
   }
 }

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -1,0 +1,101 @@
+import child_process from 'node:child_process';
+import fs from 'node:fs';
+
+/**
+ * Name of the environment variable through which a judge server tells problem-utils to run
+ * untrusted submitted programs as the given unprivileged OS user via sudo.
+ *
+ * The judge server sets this variable only when it runs the judge harness (e.g. `judge.ts`) as its
+ * own trusted user, so that problem files (test cases and the harness itself) stay unreadable to
+ * submissions while the submissions themselves run under the sandbox user. When the variable is
+ * absent or empty (local development, course authoring, or an all-sandbox judge run), commands run
+ * as the current user like before.
+ */
+export const SANDBOX_USER_ENV_NAME = 'EXERCODE_SANDBOX_USER';
+
+// Absolute path so a submission-controlled `PATH` cannot redirect the privileged `sudo`.
+const SUDO_PATH = '/usr/bin/sudo';
+
+export const sandboxUserName = process.env[SANDBOX_USER_ENV_NAME] || undefined;
+
+/**
+ * Wrap a command so it runs as the sandbox user. `umask 0` makes every file the sandboxed process
+ * creates world-writable, so the harness user can clean it up without privileges. The wrapper also
+ * restores `LD_LIBRARY_PATH`, which ld.so strips across the setuid `sudo` exec. Put `timeout`
+ * inside the wrapped command: the harness user cannot signal the root-owned `sudo` process, so an
+ * outer timer alone could not stop a runaway submission.
+ */
+export function wrapCommandWithSandboxUser(command: readonly [string, ...string[]]): [string, ...string[]] {
+  if (!sandboxUserName) return [...command];
+  return [
+    SUDO_PATH,
+    '--preserve-env',
+    '-u',
+    sandboxUserName,
+    '--',
+    'sh',
+    '-c',
+    'umask 0; if [ -n "$SANDBOX_LD_LIBRARY_PATH" ]; then export LD_LIBRARY_PATH="$SANDBOX_LD_LIBRARY_PATH"; fi; exec "$0" "$@"',
+    ...command,
+  ];
+}
+
+/**
+ * Environment overrides for sandboxed processes: a writable home and the `LD_LIBRARY_PATH`
+ * smuggled past the setuid `sudo` exec (see {@link wrapCommandWithSandboxUser}).
+ */
+export function getSandboxUserEnvOverrides(): NodeJS.ProcessEnv {
+  if (!sandboxUserName) return {};
+  return {
+    HOME: `/home/${sandboxUserName}`,
+    ...(process.env.LD_LIBRARY_PATH && { SANDBOX_LD_LIBRARY_PATH: process.env.LD_LIBRARY_PATH }),
+  };
+}
+
+/**
+ * Make harness-user-created files under the given path readable, and directories writable, for the
+ * sandbox user, so sandboxed programs can read their sources and create outputs next to them.
+ */
+export function makeAccessibleToSandboxUser(targetPath: string): void {
+  if (!sandboxUserName) return;
+  // Files owned by the sandbox user fail to chmod but are already world-writable (umask 0).
+  child_process.spawnSync('chmod', ['-R', 'a+rwX', targetPath]);
+}
+
+/**
+ * Kill all processes of the sandbox user. The harness user cannot signal another user's processes
+ * (nor the root-owned `sudo` wrapper), so this goes through sudo. Killing every sandbox process is
+ * safe because the judge server handles one request at a time. SIGTERM is followed by SIGKILL so a
+ * submission that traps SIGTERM cannot survive cleanup.
+ */
+export function killSandboxUserProcesses(): void {
+  if (!sandboxUserName) return;
+  // Two direct calls instead of one `sh -c 'pkill ...; pkill ...'`: the wrapping shell would run as
+  // the sandbox user too, so the first pkill would kill it before the second ran. Each `pkill`
+  // exits with 1 when no process matches, so ignore the exit status.
+  for (const signal of ['-TERM', '-KILL']) {
+    child_process.spawnSync(SUDO_PATH, ['-u', sandboxUserName, 'pkill', signal, '-u', sandboxUserName], {
+      // The harness environment must not be passed: sudoers forwards it verbatim, and after sudo
+      // drops privileges the helper's `/proc/<pid>/environ` becomes readable by every other
+      // sandbox process.
+      env: { PATH: '/usr/local/bin:/usr/bin:/bin' },
+    });
+  }
+}
+
+/**
+ * `fs.rm`-like removal with a fallback for trees holding sandbox-user-owned entries whose
+ * permissions block deletion (some tools chmod their outputs regardless of umask): let the sandbox
+ * user reopen its own files first, then retry.
+ */
+export async function forceRemove(targetPath: string): Promise<void> {
+  try {
+    await fs.promises.rm(targetPath, { force: true, recursive: true });
+  } catch (error) {
+    if (!sandboxUserName) throw error;
+    child_process.spawnSync(SUDO_PATH, ['-u', sandboxUserName, 'chmod', '-R', 'a+rwX', targetPath], {
+      env: { PATH: '/usr/local/bin:/usr/bin:/bin' },
+    });
+    await fs.promises.rm(targetPath, { force: true, recursive: true });
+  }
+}

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -43,6 +43,10 @@ const MINIMAL_ENV = { PATH: '/usr/local/bin:/usr/bin:/bin' } as const;
  * command through the child environment's `PATH`, so a fixed `PATH` here pins them to system paths.
  */
 export function getTrustedHelperEnv(extraEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  // Without delegation the submission runs as this same user, so there is no boundary to defend and
+  // pinning `PATH` would only break setups whose X11/`ps` binaries live elsewhere (e.g. /usr/games,
+  // /snap/bin, Nix). Keep the inherited environment there, exactly as before delegation existed.
+  if (!sandboxUserName) return { ...process.env, ...extraEnv };
   return { ...MINIMAL_ENV, ...extraEnv };
 }
 
@@ -65,6 +69,8 @@ if (sandboxUserName && sandboxUserName === os.userInfo().username) {
  */
 export function wrapCommandWithSandboxUser(command: readonly [string, ...string[]]): [string, ...string[]] {
   if (!sandboxUserName) return [...command];
+  // Idempotent; see {@link isSandboxWrappedCommand}.
+  if (isSandboxWrappedCommand(command)) return [...command];
   return [
     SUDO_PATH,
     '--preserve-env',
@@ -76,6 +82,16 @@ export function wrapCommandWithSandboxUser(command: readonly [string, ...string[
     'umask 0; if [ -n "$SANDBOX_LD_LIBRARY_PATH" ]; then export LD_LIBRARY_PATH="$SANDBOX_LD_LIBRARY_PATH"; fi; exec "$0" "$@"',
     ...command,
   ];
+}
+
+/**
+ * Whether the command was already wrapped by {@link wrapCommandWithSandboxUser}. The presets hand
+ * custom runners a wrapped command, and a runner may forward it to another helper that wraps too;
+ * a nested wrapper's inner `sudo` would run AS the sandbox user, which sudoers does not authorize,
+ * so every test case of such a problem would fail only under delegation.
+ */
+export function isSandboxWrappedCommand(command: readonly string[]): boolean {
+  return command.includes(SUDO_PATH);
 }
 
 /**
@@ -116,7 +132,12 @@ export function killSandboxUserProcesses(signals: readonly ('TERM' | 'KILL')[] =
   // would run as the sandbox user too, so the first pkill would kill it before the second ran.
   // Each `pkill` exits with 1 when no process matches, so ignore the exit status.
   for (const signal of signals) {
-    runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName]);
+    const result = runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName]);
+    // Fail closed: a submission can exhaust the PID cgroup so this `sudo` cannot even be spawned.
+    // Reporting success would leave its processes alive for the next request on this instance.
+    if (result.error) {
+      throw new Error(`failed to terminate ${sandboxUserName} processes: ${result.error.message}`);
+    }
   }
 }
 
@@ -194,8 +215,8 @@ export function startSandboxTimeoutWatchdog(timeoutSeconds: number): SandboxTime
  * passed: sudoers forwards it verbatim, and after sudo drops privileges the helper's
  * `/proc/<pid>/environ` becomes readable by every other sandbox process.
  */
-function runAsSandboxUser(command: [string, ...string[]]): void {
-  child_process.spawnSync(SUDO_PATH, ['-u', sandboxUserName as string, ...command], { env: MINIMAL_ENV });
+function runAsSandboxUser(command: [string, ...string[]]): child_process.SpawnSyncReturns<Buffer> {
+  return child_process.spawnSync(SUDO_PATH, ['-u', sandboxUserName as string, ...command], { env: MINIMAL_ENV });
 }
 
 /**

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -1,6 +1,7 @@
 import child_process from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
+import path from 'node:path';
 
 /**
  * Name of the environment variable through which a judge server tells problem-utils to run
@@ -14,8 +15,11 @@ import os from 'node:os';
  *
  * Contract for the delegating judge server (delegation is Linux-only — sudo user separation and
  * `/home/<user>` homes are provisioned in the judge Docker image; never set this on macOS):
- * - The harness process environment is forwarded verbatim to sandboxed submissions (sudo runs with
- *   `--preserve-env`), so it must not contain secrets beyond what submissions may see.
+ * - The harness process environment is forwarded to sandboxed submissions (sudo runs with
+ *   `--preserve-env`), so it must not contain secrets beyond what submissions may see. The one
+ *   exception is the set glibc strips when executing the setuid `sudo` (secure-execution mode:
+ *   `LD_*`, `TMPDIR`, `LOCPATH`, `NLSPATH`, `TZDIR`, … — see ld.so(8)); no sudoers setting can
+ *   recover those, and only `LD_LIBRARY_PATH` is restored, by the wrapper below.
  * - sudoers must let the harness user run arbitrary commands as the sandbox user without a
  *   password, pass the environment through, and keep sudo off a pseudo-terminal (a pty would merge
  *   stderr into stdout and CRLF-mangle output when the harness happens to run from a terminal):
@@ -125,11 +129,14 @@ export function prependInsideSandboxWrapper(
 export function getSandboxUserEnvOverrides(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   if (!sandboxUserName) return {};
   const sourceEnv = env ?? process.env;
-  const ldLibraryPath = sourceEnv.LD_LIBRARY_PATH ?? process.env.LD_LIBRARY_PATH;
+  const submissionOnlyEnv = unwrapSubmissionOnlyEnv(sourceEnv);
+  // A submission-only `LD_LIBRARY_PATH` must be the one smuggled past the exec, not the harness's.
+  const ldLibraryPath = submissionOnlyEnv.LD_LIBRARY_PATH ?? sourceEnv.LD_LIBRARY_PATH ?? process.env.LD_LIBRARY_PATH;
   return {
     HOME: `/home/${sandboxUserName}`,
+    ...submissionOnlyEnv,
+    // Last: the wrapper reads this one, so a caller must not be able to overwrite it.
     ...(ldLibraryPath && { SANDBOX_LD_LIBRARY_PATH: ldLibraryPath }),
-    ...unwrapSubmissionOnlyEnv(sourceEnv),
   };
 }
 
@@ -270,7 +277,10 @@ function runAsSandboxUser(command: [string, ...string[]]): child_process.SpawnSy
 
 /**
  * `fs.rm`-like removal with a fallback for trees holding sandbox-user-owned entries whose
- * permissions block deletion: let the sandbox user reopen its own files first, then retry.
+ * permissions block deletion: let the sandbox user reopen its own files first, then retry. The
+ * containing directory is relaxed as well — unlinking an entry needs write permission on its
+ * parent, so a submission that chmods a directory it owns would otherwise make everything inside it
+ * undeletable.
  */
 export async function forceRemove(targetPath: string): Promise<void> {
   try {
@@ -278,6 +288,8 @@ export async function forceRemove(targetPath: string): Promise<void> {
   } catch (error) {
     if (!sandboxUserName) throw error;
     relaxPermissionsAsSandboxUser(targetPath);
+    // Not recursive: only the containing directory's own write bit governs the unlink.
+    runAsSandboxUser(['chmod', 'a+rwX', path.dirname(targetPath)]);
     await fs.promises.rm(targetPath, { force: true, recursive: true });
   }
 }

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -54,7 +54,9 @@ export function getTrustedHelperEnv(extraEnv?: NodeJS.ProcessEnv): NodeJS.Proces
   // pinning `PATH` would only break setups whose X11/`ps` binaries live elsewhere (e.g. /usr/games,
   // /snap/bin, Nix). Keep the inherited environment there, exactly as before delegation existed.
   if (!sandboxUserName) return { ...process.env, ...extraEnv };
-  return { ...MINIMAL_ENV, ...extraEnv };
+  // `PATH` last: a caller passing a whole environment through would otherwise reinstate the
+  // submission-influenced one this function exists to replace.
+  return { ...extraEnv, PATH: MINIMAL_ENV.PATH };
 }
 
 export const sandboxUserName = process.env[SANDBOX_USER_ENV_NAME] || undefined;
@@ -66,6 +68,14 @@ if (sandboxUserName && sandboxUserName === os.userInfo().username) {
     `${SANDBOX_USER_ENV_NAME} must name a different OS user than the one running the harness (got "${sandboxUserName}"). Leave it unset to run everything as the current user.`
   );
 }
+
+/**
+ * The deadline supervisor. Absolute under delegation: the wrapper's `exec "$0"` resolves it through
+ * the submission's own `PATH` (which a judge server may set via {@link SANDBOX_ENV_PREFIX}), so a
+ * bare name would let a submission replace the very process that enforces its time limit. The bare
+ * name is kept without delegation, where `timeout` may live elsewhere (Homebrew coreutils).
+ */
+export const TIMEOUT_COMMAND = sandboxUserName ? '/usr/bin/timeout' : 'timeout';
 
 /**
  * Wrap a command so it runs as the sandbox user. `umask 0` makes every file the sandboxed process

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -1,5 +1,6 @@
 import child_process from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 
 /**
  * Name of the environment variable through which a judge server tells problem-utils to run
@@ -34,6 +35,14 @@ const SLEEP_PATH = '/bin/sleep';
 const MINIMAL_ENV = { PATH: '/usr/local/bin:/usr/bin:/bin' } as const;
 
 export const sandboxUserName = process.env[SANDBOX_USER_ENV_NAME] || undefined;
+
+// Fail fast on the catastrophic misconfiguration where the sandbox user is the harness's own user:
+// cleanup (`killSandboxUserProcesses`) would then SIGKILL the harness itself on the first run.
+if (sandboxUserName && sandboxUserName === os.userInfo().username) {
+  throw new Error(
+    `${SANDBOX_USER_ENV_NAME} must name a different OS user than the one running the harness (got "${sandboxUserName}"). Leave it unset to run everything as the current user.`
+  );
+}
 
 /**
  * Wrap a command so it runs as the sandbox user. `umask 0` makes every file the sandboxed process

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -15,9 +15,13 @@ import fs from 'node:fs';
  * - The harness process environment is forwarded verbatim to sandboxed submissions (sudo runs with
  *   `--preserve-env`), so it must not contain secrets beyond what submissions may see.
  * - sudoers must let the harness user run arbitrary commands as the sandbox user without a
- *   password and pass the environment through (e.g. `Defaults:<harness> !env_reset, !env_delete,
- *   !env_check, !secure_path` plus `<harness> ALL=(<sandbox>) NOPASSWD:SETENV: ALL`).
- * - The sandbox user's home directory must exist at `/home/<sandbox user>` and be writable.
+ *   password, pass the environment through, and keep sudo off a pseudo-terminal (a pty would merge
+ *   stderr into stdout and CRLF-mangle output when the harness happens to run from a terminal):
+ *   e.g. `Defaults:<harness> !env_reset, !env_delete, !env_check, !secure_path, !use_pty` plus
+ *   `<harness> ALL=(<sandbox>) NOPASSWD:SETENV: ALL`.
+ * - The sandbox user's home directory must exist at `/home/<sandbox user>` and be writable. It is
+ *   shared across sequential requests, so the server is responsible for resetting whatever
+ *   cross-request persistence there matters to it.
  */
 export const SANDBOX_USER_ENV_NAME = 'EXERCODE_SANDBOX_USER';
 
@@ -25,6 +29,7 @@ export const SANDBOX_USER_ENV_NAME = 'EXERCODE_SANDBOX_USER';
 // harness user executes (`sudo` is also setuid and must be the real one).
 const SUDO_PATH = '/usr/bin/sudo';
 const CHMOD_PATH = '/bin/chmod';
+const SLEEP_PATH = '/bin/sleep';
 // Minimal environment for trusted helper processes; never forward the harness environment to them.
 const MINIMAL_ENV = { PATH: '/usr/local/bin:/usr/bin:/bin' } as const;
 
@@ -117,7 +122,7 @@ export function startSandboxTimeoutWatchdog(timeoutSeconds: number): () => void 
   const deadlineSeconds = Math.ceil(timeoutSeconds) + 5;
   const watchdog = child_process.spawn(
     '/bin/sh',
-    ['-c', `sleep ${deadlineSeconds}; ${SUDO_PATH} -u "$1" pkill -KILL -u "$1"`, 'sh', sandboxUserName],
+    ['-c', `${SLEEP_PATH} ${deadlineSeconds}; ${SUDO_PATH} -u "$1" pkill -KILL -u "$1"`, 'sh', sandboxUserName],
     { detached: true, stdio: 'ignore', env: MINIMAL_ENV }
   );
   watchdog.unref();

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -35,6 +35,17 @@ const SLEEP_PATH = '/bin/sleep';
 // Minimal environment for trusted helper processes; never forward the harness environment to them.
 const MINIMAL_ENV = { PATH: '/usr/local/bin:/usr/bin:/bin' } as const;
 
+/**
+ * Environment for helper processes the *trusted* harness user runs (`ps`, `xwininfo`, `Xvfb`, …).
+ * The judge server overlays caller-supplied variables onto the harness environment, and a sandboxed
+ * submission can create executables in its persistent home, so resolving these helpers through the
+ * inherited `PATH` would hand the submission code execution as the harness user. Node resolves the
+ * command through the child environment's `PATH`, so a fixed `PATH` here pins them to system paths.
+ */
+export function getTrustedHelperEnv(extraEnv?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return { ...MINIMAL_ENV, ...extraEnv };
+}
+
 export const sandboxUserName = process.env[SANDBOX_USER_ENV_NAME] || undefined;
 
 // Fail fast on the catastrophic misconfiguration where the sandbox user is the harness's own user:
@@ -119,30 +130,62 @@ export function relaxPermissionsAsSandboxUser(targetPath: string): void {
   runAsSandboxUser(['chmod', '-R', 'a+rwX', targetPath]);
 }
 
+/** Cancels a {@link startSandboxTimeoutWatchdog}; `fired` reports whether its deadline elapsed. */
+export interface SandboxTimeoutWatchdog {
+  cancel(): void;
+  fired(): boolean;
+}
+
 /**
- * Start a harness-owned watchdog that force-kills every sandbox process after the given deadline,
- * and return a function that cancels it. A sandboxed submission can signal its own `timeout`
- * supervisor (same UID), and a synchronous spawn blocks the harness's event loop, so without this
- * external deadline a submission could run until the outer judge-server limit. The watchdog's
- * `sh`/`sleep` run as the harness user, out of the submission's reach; killing the watchdog's
- * process group cancels it before it spawns sudo.
+ * Start a harness-owned watchdog that force-kills every sandbox process after the given deadline.
+ * A sandboxed submission can signal its own `timeout` supervisor (same UID), and a synchronous
+ * spawn blocks the harness's event loop, so without this external deadline a submission could run
+ * until the outer judge-server limit. The watchdog's `sh`/`sleep` run as the harness user, out of
+ * the submission's reach; killing the watchdog's process group cancels it before it spawns sudo.
+ *
+ * ALWAYS cancel in a `finally`: the watchdog is detached and `unref`'d, so a leaked one keeps
+ * running after the harness exits and would SIGKILL a later request's submission.
  */
-export function startSandboxTimeoutWatchdog(timeoutSeconds: number): () => void {
-  if (!sandboxUserName) return () => {};
+export function startSandboxTimeoutWatchdog(timeoutSeconds: number): SandboxTimeoutWatchdog {
+  if (!sandboxUserName) return { cancel: () => {}, fired: () => false };
+
   const deadlineSeconds = Math.ceil(timeoutSeconds) + 5;
   const watchdog = child_process.spawn(
     '/bin/sh',
     ['-c', `${SLEEP_PATH} ${deadlineSeconds}; ${SUDO_PATH} -u "$1" pkill -KILL -u "$1"`, 'sh', sandboxUserName],
     { detached: true, stdio: 'ignore', env: MINIMAL_ENV }
   );
+  // Without a listener, a spawn failure (e.g. the submission exhausted the PID cgroup) would be an
+  // unhandled 'error' event that terminates the harness. Fail closed instead: callers check
+  // `fired()`, and a watchdog that never started reports its deadline as elapsed.
+  let spawnFailed = false;
+  watchdog.on('error', () => {
+    spawnFailed = true;
+  });
+  let exited = false;
+  watchdog.on('exit', () => {
+    exited = true;
+  });
   watchdog.unref();
-  return () => {
-    if (watchdog.pid === undefined) return;
-    try {
-      process.kill(-watchdog.pid, 'SIGKILL');
-    } catch {
-      // The watchdog already fired and exited.
-    }
+
+  const startTimeMilliseconds = Date.now();
+  let cancelled = false;
+  return {
+    cancel: () => {
+      cancelled = true;
+      if (watchdog.pid === undefined || exited) return;
+      try {
+        process.kill(-watchdog.pid, 'SIGKILL');
+      } catch {
+        // The watchdog already fired and exited.
+      }
+    },
+    // The `exit`/`error` events cannot be observed from a synchronous caller (they need the event
+    // loop), so decide by elapsed time, which is what the watchdog itself waits on.
+    fired: () =>
+      spawnFailed ||
+      watchdog.pid === undefined ||
+      (!cancelled && Date.now() - startTimeMilliseconds >= deadlineSeconds * 1000),
   };
 }
 

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -12,7 +12,8 @@ import os from 'node:os';
  * absent or empty (local development, course authoring, or an all-sandbox judge run), commands run
  * as the current user like before.
  *
- * Contract for the delegating judge server:
+ * Contract for the delegating judge server (delegation is Linux-only — sudo user separation and
+ * `/home/<user>` homes are provisioned in the judge Docker image; never set this on macOS):
  * - The harness process environment is forwarded verbatim to sandboxed submissions (sudo runs with
  *   `--preserve-env`), so it must not contain secrets beyond what submissions may see.
  * - sudoers must let the harness user run arbitrary commands as the sandbox user without a

--- a/src/helpers/spawnSyncWithTimeout.ts
+++ b/src/helpers/spawnSyncWithTimeout.ts
@@ -1,8 +1,15 @@
 import child_process from 'node:child_process';
 import os from 'node:os';
 
+import { getSandboxUserEnvOverrides, wrapCommandWithSandboxUser } from './sandboxUser.js';
+
 const TIME_COMMAND = [os.platform() === 'darwin' ? 'gtime' : '/usr/bin/time', '--format', '%e %M'] as const;
 
+/**
+ * Run an untrusted (submission-derived) command with a timeout. When a judge server delegates
+ * untrusted execution via `EXERCODE_SANDBOX_USER` (see `sandboxUser.ts`), the whole command,
+ * including `timeout`, runs as the sandbox user so the timer can signal the sandboxed process.
+ */
 export function spawnSyncWithTimeout(
   command: string,
   args: readonly string[],
@@ -11,11 +18,17 @@ export function spawnSyncWithTimeout(
 ): child_process.SpawnSyncReturns<string> & { timeSeconds: number; memoryBytes: number } {
   const startTimeMilliseconds = Date.now();
 
-  const spawnResult = child_process.spawnSync(
+  const wrappedCommand = wrapCommandWithSandboxUser([
     'timeout',
-    [timeoutSeconds.toFixed(3), ...TIME_COMMAND, command, ...args],
-    options
-  );
+    timeoutSeconds.toFixed(3),
+    ...TIME_COMMAND,
+    command,
+    ...args,
+  ]);
+  const spawnResult = child_process.spawnSync(wrappedCommand[0], wrappedCommand.slice(1), {
+    ...options,
+    env: { ...(options.env ?? process.env), ...getSandboxUserEnvOverrides() },
+  });
 
   const stopTimeMilliseconds = Date.now();
 

--- a/src/helpers/spawnSyncWithTimeout.ts
+++ b/src/helpers/spawnSyncWithTimeout.ts
@@ -6,6 +6,7 @@ import {
   killSandboxUserProcesses,
   sandboxUserName,
   startSandboxTimeoutWatchdog,
+  TIMEOUT_COMMAND,
   wrapCommandWithSandboxUser,
 } from './sandboxUser.js';
 
@@ -28,7 +29,7 @@ export function spawnSyncWithTimeout(
 
   const env = { ...(options.env ?? process.env) };
   const wrappedCommand = wrapCommandWithSandboxUser([
-    'timeout',
+    TIMEOUT_COMMAND,
     timeoutSeconds.toFixed(3),
     ...TIME_COMMAND,
     command,

--- a/src/helpers/spawnSyncWithTimeout.ts
+++ b/src/helpers/spawnSyncWithTimeout.ts
@@ -1,14 +1,22 @@
 import child_process from 'node:child_process';
 import os from 'node:os';
 
-import { getSandboxUserEnvOverrides, wrapCommandWithSandboxUser } from './sandboxUser.js';
+import {
+  getSandboxUserEnvOverrides,
+  killSandboxUserProcesses,
+  sandboxUserName,
+  startSandboxTimeoutWatchdog,
+  wrapCommandWithSandboxUser,
+} from './sandboxUser.js';
 
 const TIME_COMMAND = [os.platform() === 'darwin' ? 'gtime' : '/usr/bin/time', '--format', '%e %M'] as const;
 
 /**
  * Run an untrusted (submission-derived) command with a timeout. When a judge server delegates
  * untrusted execution via `EXERCODE_SANDBOX_USER` (see `sandboxUser.ts`), the whole command,
- * including `timeout`, runs as the sandbox user so the timer can signal the sandboxed process.
+ * including `timeout`, runs as the sandbox user so the timer can signal the sandboxed process; a
+ * harness-owned watchdog enforces the deadline even if the submission kills its own `timeout`, and
+ * leftover sandbox processes (e.g. daemonized children) are killed after every run.
  */
 export function spawnSyncWithTimeout(
   command: string,
@@ -18,6 +26,7 @@ export function spawnSyncWithTimeout(
 ): child_process.SpawnSyncReturns<string> & { timeSeconds: number; memoryBytes: number } {
   const startTimeMilliseconds = Date.now();
 
+  const env = { ...(options.env ?? process.env) };
   const wrappedCommand = wrapCommandWithSandboxUser([
     'timeout',
     timeoutSeconds.toFixed(3),
@@ -25,10 +34,17 @@ export function spawnSyncWithTimeout(
     command,
     ...args,
   ]);
-  const spawnResult = child_process.spawnSync(wrappedCommand[0], wrappedCommand.slice(1), {
-    ...options,
-    env: { ...(options.env ?? process.env), ...getSandboxUserEnvOverrides() },
-  });
+  const stopWatchdog = startSandboxTimeoutWatchdog(timeoutSeconds);
+  let spawnResult: child_process.SpawnSyncReturns<string>;
+  try {
+    spawnResult = child_process.spawnSync(wrappedCommand[0], wrappedCommand.slice(1), {
+      ...options,
+      env: { ...env, ...getSandboxUserEnvOverrides(env) },
+    });
+  } finally {
+    stopWatchdog();
+    if (sandboxUserName) killSandboxUserProcesses();
+  }
 
   const stopTimeMilliseconds = Date.now();
 

--- a/src/helpers/spawnSyncWithTimeout.ts
+++ b/src/helpers/spawnSyncWithTimeout.ts
@@ -34,15 +34,19 @@ export function spawnSyncWithTimeout(
     command,
     ...args,
   ]);
-  const stopWatchdog = startSandboxTimeoutWatchdog(timeoutSeconds);
+  const watchdog = startSandboxTimeoutWatchdog(timeoutSeconds);
   let spawnResult: child_process.SpawnSyncReturns<string>;
+  let watchdogFired: boolean;
   try {
     spawnResult = child_process.spawnSync(wrappedCommand[0], wrappedCommand.slice(1), {
       ...options,
       env: { ...env, ...getSandboxUserEnvOverrides(env) },
     });
   } finally {
-    stopWatchdog();
+    // Read the watchdog state before cancelling, then always cancel: a leaked watchdog is detached
+    // and would SIGKILL a later request's submission.
+    watchdogFired = watchdog.fired();
+    watchdog.cancel();
     if (sandboxUserName) killSandboxUserProcesses();
   }
 
@@ -53,8 +57,10 @@ export function spawnSyncWithTimeout(
   const timeSeconds = Number(match?.[1]) || (stopTimeMilliseconds - startTimeMilliseconds) / 1000;
   const memoryBytes = Number(match?.[2]) * 1024 || 0;
 
-  // timeout
-  if (spawnResult.status === 124) {
+  // `timeout` reports 124, but a sandboxed submission can kill its own same-UID `timeout` and be
+  // stopped by the watchdog instead, which surfaces as a signal-derived status. Both are timeouts:
+  // reporting the latter as a runtime error would mislabel a submission that outran its deadline.
+  if (spawnResult.status === 124 || watchdogFired) {
     return { ...spawnResult, status: 0, stderr, timeSeconds: timeoutSeconds + 1e-3, memoryBytes };
   }
 

--- a/src/helpers/startHttpServer.ts
+++ b/src/helpers/startHttpServer.ts
@@ -2,6 +2,9 @@ import fs from 'node:fs';
 import http from 'node:http';
 import path from 'node:path';
 
+import { isContainedPath } from './safeFs.js';
+import { sandboxUserName } from './sandboxUser.js';
+
 export interface HttpServer {
   [Symbol.asyncDispose](): Promise<void>;
   url: string;
@@ -22,6 +25,15 @@ export function startHttpServer(dir: string): HttpServer {
     const pathnameWithIndexHtml = pathname.endsWith('/') ? path.join(pathname, 'index.html') : pathname;
 
     const filePath = path.join(dir, pathnameWithIndexHtml);
+
+    // Under delegation this read runs as the trusted harness user while the served directory
+    // belongs to the sandboxed submission, so a planted symlink (or symlinked parent) pointing at
+    // e.g. the problem's expected outputs would otherwise be served straight back to the page.
+    if (!isServableSubmissionPath(dir, filePath)) {
+      response.statusCode = 404;
+      response.end();
+      return;
+    }
 
     if (fs.existsSync(filePath)) {
       try {
@@ -71,6 +83,18 @@ const CONTENT_TYPE_BY_SUFFIX: Record<string, string> = {
   '.png': 'image/png',
   '.svg': 'image/svg+xml',
 };
+
+function isServableSubmissionPath(dir: string, filePath: string): boolean {
+  // Without user separation the page's own code can read these files anyway, so keep the previous
+  // behavior and stay usable for course authoring outside the judge image.
+  if (!sandboxUserName) return true;
+  try {
+    return isContainedPath(fs.realpathSync(dir), fs.realpathSync(filePath));
+  } catch {
+    // A missing file is reported as 404 below; anything unresolvable is not servable either.
+    return !fs.existsSync(filePath);
+  }
+}
 
 function getContentType(pathname: string): string {
   for (const [suffix, contentType] of Object.entries(CONTENT_TYPE_BY_SUFFIX)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './helpers/printTestCaseResult.js';
 export * from './helpers/removeCommentsInSourceCode.js';
 export * from './helpers/runCommandInTemporaryPackageManagerProject.js';
 export * from './helpers/runPythonInTemporaryUvProject.js';
+export * from './helpers/safeFs.js';
 export * from './helpers/sandboxUser.js';
 export * from './helpers/sourceCodeGrammars.js';
 export * from './helpers/startHttpServer.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './helpers/printTestCaseResult.js';
 export * from './helpers/removeCommentsInSourceCode.js';
 export * from './helpers/runCommandInTemporaryPackageManagerProject.js';
 export * from './helpers/runPythonInTemporaryUvProject.js';
+export * from './helpers/sandboxUser.js';
 export * from './helpers/sourceCodeGrammars.js';
 export * from './helpers/startHttpServer.js';
 export * from './types/decisionCode.js';

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -77,6 +77,12 @@ export interface CommandJudgePresetOptions<
   limits?: CommandJudgeLimits;
   runTimeoutSeconds?: number;
   readTestCases?: (problemDir: string) => Promise<readonly TTestCase[]>;
+  /**
+   * Runs as the trusted harness user with the submission's `cwd`. Fixture files it creates there
+   * must be written with `createDirectoryWithoutFollowingSymlinks`/`writeFileWithoutFollowingSymlinks`
+   * (both exported): a submission can plant a symlink at a fixture path, and a plain `fs.writeFile`
+   * would follow it into a file only the harness can write.
+   */
   resolveInput?: (context: { testCase: TTestCase; cwd: string; env: NodeJS.ProcessEnv }) => Promise<string> | string;
   runCommand?: (context: {
     testCase: TTestCase;

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -12,6 +12,7 @@ import { parseArgs } from '../helpers/parseArgs.js';
 import { printDebugBanner } from '../helpers/printDebugBanner.js';
 import { printTestCaseResult } from '../helpers/printTestCaseResult.js';
 import { readOutputFiles } from '../helpers/readOutputFiles.js';
+import { runCustomRunner } from '../helpers/runCustomRunner.js';
 import {
   getSandboxUserEnvOverrides,
   makeAccessibleToSandboxUser,
@@ -83,6 +84,11 @@ export interface CommandJudgePresetOptions<
      * The command to run. Under `EXERCODE_SANDBOX_USER` delegation it is already wrapped so it
      * executes as the sandbox user; spawn it as given (with the supplied `env`) instead of
      * reconstructing it, or the submission runs as the trusted harness user.
+     *
+     * Its direct child is then a root-owned `sudo` whose descendants belong to the sandbox user, so
+     * the handler cannot signal them: enforce `timeLimitSeconds` with `startSandboxTimeoutWatchdog`
+     * and `killSandboxUserProcesses` (both exported) rather than `child.kill()` or an outer
+     * `timeout`. The preset terminates leftover sandbox processes after the handler returns.
      */
     command: readonly [string, ...string[]];
     stdin: string;
@@ -275,17 +281,20 @@ async function runCommandJudgeForCwd<
       }
 
       runResult = options.runCommand
-        ? await options.runCommand({
-            testCase,
-            // Hand custom runners a command that is already sandbox-wrapped, and the matching
-            // environment: they spawn it themselves, so an unwrapped command would run the
-            // submission as the trusted harness user and defeat the delegation boundary.
-            command: wrapCommandWithSandboxUser(command),
-            stdin,
-            cwd,
-            env: { ...env, ...getSandboxUserEnvOverrides(env) },
-            timeLimitSeconds,
-          })
+        ? await runCustomRunner(
+            () =>
+              // Hand custom runners a command that is already sandbox-wrapped, and the matching
+              // environment: they spawn it themselves, so an unwrapped command would run the
+              // submission as the trusted harness user and defeat the delegation boundary.
+              options.runCommand?.({
+                testCase,
+                command: wrapCommandWithSandboxUser(command),
+                stdin,
+                cwd,
+                env: { ...env, ...getSandboxUserEnvOverrides(env) },
+                timeLimitSeconds,
+              }) as Promise<TRunResult>
+          )
         : (runCommand(command, {
             stdin,
             cwd,

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -12,7 +12,11 @@ import { parseArgs } from '../helpers/parseArgs.js';
 import { printDebugBanner } from '../helpers/printDebugBanner.js';
 import { printTestCaseResult } from '../helpers/printTestCaseResult.js';
 import { readOutputFiles } from '../helpers/readOutputFiles.js';
-import { makeAccessibleToSandboxUser } from '../helpers/sandboxUser.js';
+import {
+  getSandboxUserEnvOverrides,
+  makeAccessibleToSandboxUser,
+  wrapCommandWithSandboxUser,
+} from '../helpers/sandboxUser.js';
 import { readProblemMarkdownFrontMatter } from '../helpers/readProblemMarkdownFrontMatter.js';
 import { readTestCases as readFileTestCases } from '../helpers/readTestCases.js';
 import {
@@ -75,6 +79,11 @@ export interface CommandJudgePresetOptions<
   resolveInput?: (context: { testCase: TTestCase; cwd: string; env: NodeJS.ProcessEnv }) => Promise<string> | string;
   runCommand?: (context: {
     testCase: TTestCase;
+    /**
+     * The command to run. Under `EXERCODE_SANDBOX_USER` delegation it is already wrapped so it
+     * executes as the sandbox user; spawn it as given (with the supplied `env`) instead of
+     * reconstructing it, or the submission runs as the trusted harness user.
+     */
     command: readonly [string, ...string[]];
     stdin: string;
     cwd: string;
@@ -268,10 +277,13 @@ async function runCommandJudgeForCwd<
       runResult = options.runCommand
         ? await options.runCommand({
             testCase,
-            command,
+            // Hand custom runners a command that is already sandbox-wrapped, and the matching
+            // environment: they spawn it themselves, so an unwrapped command would run the
+            // submission as the trusted harness user and defeat the delegation boundary.
+            command: wrapCommandWithSandboxUser(command),
             stdin,
             cwd,
-            env,
+            env: { ...env, ...getSandboxUserEnvOverrides(env) },
             timeLimitSeconds,
           })
         : (runCommand(command, {

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -12,6 +12,7 @@ import { parseArgs } from '../helpers/parseArgs.js';
 import { printDebugBanner } from '../helpers/printDebugBanner.js';
 import { printTestCaseResult } from '../helpers/printTestCaseResult.js';
 import { readOutputFiles } from '../helpers/readOutputFiles.js';
+import { makeAccessibleToSandboxUser } from '../helpers/sandboxUser.js';
 import { readProblemMarkdownFrontMatter } from '../helpers/readProblemMarkdownFrontMatter.js';
 import { readTestCases as readFileTestCases } from '../helpers/readTestCases.js';
 import {
@@ -167,6 +168,9 @@ async function runCommandJudgeForCwd<
   params: JudgeParams,
   options: CommandJudgePresetOptions<TTestCase, TRunResult>
 ): Promise<{ allAccepted: boolean }> {
+  // The sandboxed submission must read its sources and write build/run outputs in its directory.
+  makeAccessibleToSandboxUser(cwd);
+
   const problemMarkdownFrontMatter = await readProblemMarkdownFrontMatter(problemDir);
   const testCases = await (options.readTestCases ?? readCommandTestCases)(problemDir);
   const prebuildTestCaseId = testCases[0]?.id ?? 'prebuild';

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -21,6 +21,7 @@ import {
   killSandboxUserProcesses,
   makeAccessibleToSandboxUser,
   sandboxUserName,
+  startSandboxTimeoutWatchdog,
   wrapCommandWithSandboxUser,
 } from '../helpers/sandboxUser.js';
 import { spawnSyncWithTimeout } from '../helpers/spawnSyncWithTimeout.js';
@@ -359,6 +360,9 @@ export async function guiCommandJudgePreset<TTestCase extends BaseGuiTestCase = 
     });
     await cleanWorkingDirectory(args.cwd, cwdSnapshot);
   } finally {
+    // Sweep any sandbox processes the run left behind (e.g. a SIGTERM-ignoring forked child) so they
+    // cannot race the harness's output reads or survive into the next test case/request.
+    if (sandboxUserName) killSandboxUserProcesses();
     await displayServer?.dispose();
   }
 }
@@ -495,6 +499,10 @@ async function spawnGuiProgram(context: {
   let screenshots: GuiScreenshotFile[] = [];
   const startTimeSeconds = Date.now() / 1000;
   let sampledMemoryBytes = 0;
+  // A submission can signal its own sandboxed `timeout` and then wedge the event loop (e.g.
+  // XGrabServer makes the synchronous `xwininfo`/`maim` block), so a harness-owned watchdog
+  // force-kills the sandbox user at the deadline; killing the client also releases its X grab.
+  const stopWatchdog = startSandboxTimeoutWatchdog(context.timeLimitSeconds);
 
   child.stdout.on('data', (chunk: string) => {
     stdout += chunk;
@@ -561,6 +569,7 @@ async function spawnGuiProgram(context: {
     child.removeAllListeners('error');
   }
   await stopProcess(child);
+  stopWatchdog();
   if (spawnError) throw spawnError;
   const {
     memoryBytes,
@@ -670,12 +679,13 @@ async function ensureDisplayServer(): Promise<{ display: string; dispose: () => 
 
 async function stopProcess(child: childProcess.ChildProcess): Promise<void> {
   if (!child.pid) return;
-  // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes,
-  // so go through sudo, keeping the same TERM → grace → KILL sequence as the direct path.
+  // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes, so
+  // go through sudo. SIGKILL is unconditional after the grace period: `child.exitCode` reflects only
+  // the sudo wrapper, so a daemonized child that ignored SIGTERM would survive if we gated on it.
   if (sandboxUserName) {
     killSandboxUserProcesses(['TERM']);
     await wait(PROCESS_SHUTDOWN_WAIT_SECONDS * 1000);
-    if (child.exitCode === null) killSandboxUserProcesses(['KILL']);
+    killSandboxUserProcesses(['KILL']);
     return;
   }
   killProcessGroup(child.pid, 'SIGTERM');
@@ -686,12 +696,9 @@ async function stopProcess(child: childProcess.ChildProcess): Promise<void> {
 function readProcessGroupMemoryBytes(processGroupId: number | undefined): number {
   if (!processGroupId || process.platform !== 'linux') return 0;
 
-  // Under delegation the child pid belongs to sudo, whose command may run in a different process
-  // group (sudo's use_pty mode calls setsid), so sample by user instead of by group there.
-  const psArgs = sandboxUserName
-    ? ['-o', 'rss=', '--no-headers', '-u', sandboxUserName]
-    : ['-o', 'rss=', '--no-headers', '--pgroup', String(processGroupId)];
-  const result = childProcess.spawnSync('/usr/bin/ps', psArgs, {
+  // The delegation contract requires sudoers `!use_pty`, so sudo execs the command in place and it
+  // stays in the detached child's process group; `--pgroup` therefore still captures it there.
+  const result = childProcess.spawnSync('ps', ['-o', 'rss=', '--no-headers', '--pgroup', String(processGroupId)], {
     encoding: 'utf8',
   });
   if (result.error || result.status !== 0 || !result.stdout) return 0;

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -606,8 +606,10 @@ async function spawnGuiProgram(context: {
     }
     // A submission can kill its own same-UID `timeout` and be stopped by the watchdog instead,
     // which surfaces as a SIGKILL rather than a deadline. Report that as the timeout it is, not as
-    // the runtime error the signal would otherwise imply.
-    const watchdogFired = watchdog.fired();
+    // the runtime error the signal would otherwise imply — but only when the child's fate is what
+    // decided the verdict. A `stable_screenshot` (or the loop's own `timeout`) was already decided
+    // from the screenshots, so the watchdog must not overwrite it.
+    const watchdogFired = stopReason === 'process_exit' && watchdog.fired();
     await stopProcess(child);
     if (spawnError) throw spawnError;
     const {

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -16,6 +16,12 @@ import { printTestCaseResult } from '../helpers/printTestCaseResult.js';
 import { readOutputFiles } from '../helpers/readOutputFiles.js';
 import { readProblemMarkdownFrontMatter } from '../helpers/readProblemMarkdownFrontMatter.js';
 import { readTestCases as readFileTestCases } from '../helpers/readTestCases.js';
+import {
+  getSandboxUserEnvOverrides,
+  killSandboxUserProcesses,
+  sandboxUserName,
+  wrapCommandWithSandboxUser,
+} from '../helpers/sandboxUser.js';
 import { spawnSyncWithTimeout } from '../helpers/spawnSyncWithTimeout.js';
 import { DecisionCode } from '../types/decisionCode.js';
 import { languageIdToDefinition } from '../types/language.js';
@@ -460,10 +466,15 @@ async function spawnGuiProgram(context: {
   screenshotWaitSeconds: number;
   stopDetectionThreshold: number;
 }): Promise<GuiCommandRunResult> {
-  const wrappedCommand = ['timeout', context.timeLimitSeconds.toFixed(3), ...TIME_COMMAND, ...context.command] as const;
+  const wrappedCommand = wrapCommandWithSandboxUser([
+    'timeout',
+    context.timeLimitSeconds.toFixed(3),
+    ...TIME_COMMAND,
+    ...context.command,
+  ]);
   const child = childProcess.spawn(wrappedCommand[0], wrappedCommand.slice(1), {
     cwd: context.cwd,
-    env: context.env,
+    env: { ...context.env, ...getSandboxUserEnvOverrides() },
     detached: process.platform !== 'win32',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
@@ -655,6 +666,11 @@ async function ensureDisplayServer(): Promise<{ display: string; dispose: () => 
 
 async function stopProcess(child: childProcess.ChildProcess): Promise<void> {
   if (!child.pid) return;
+  // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes.
+  if (sandboxUserName) {
+    killSandboxUserProcesses();
+    return;
+  }
   killProcessGroup(child.pid, 'SIGTERM');
   await wait(PROCESS_SHUTDOWN_WAIT_SECONDS * 1000);
   if (child.exitCode === null) killProcessGroup(child.pid, 'SIGKILL');

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -504,12 +504,24 @@ async function spawnGuiProgram(context: {
     ...TIME_COMMAND,
     ...context.command,
   ]);
-  const child = childProcess.spawn(wrappedCommand[0], wrappedCommand.slice(1), {
-    cwd: context.cwd,
-    env: { ...context.env, ...getSandboxUserEnvOverrides(context.env) },
-    detached: process.platform !== 'win32',
-    stdio: ['pipe', 'pipe', 'pipe'],
-  });
+  // A submission can signal its own sandboxed `timeout` and then wedge the event loop (e.g.
+  // XGrabServer makes the synchronous `xwininfo`/`maim` block), so a harness-owned watchdog
+  // force-kills the sandbox user at the deadline; killing the client also releases its X grab.
+  // Armed before the submission starts: a submission that exhausts the PID cgroup would otherwise
+  // prevent the watchdog from spawning at all.
+  const watchdog = startSandboxTimeoutWatchdog(context.timeLimitSeconds);
+  let child: childProcess.ChildProcessWithoutNullStreams;
+  try {
+    child = childProcess.spawn(wrappedCommand[0], wrappedCommand.slice(1), {
+      cwd: context.cwd,
+      env: { ...context.env, ...getSandboxUserEnvOverrides(context.env) },
+      detached: process.platform !== 'win32',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    watchdog.cancel();
+    throw error;
+  }
 
   child.stdout.setEncoding('utf8');
   child.stderr.setEncoding('utf8');
@@ -519,15 +531,11 @@ async function spawnGuiProgram(context: {
   let exitCode: number | undefined;
   let spawnError: Error | undefined;
   let stopReason: GuiCommandRunResult['stopReason'] = 'process_exit';
+  let submissionStopped = false;
   const screenshotSignaturesHistory: string[][] = [];
   let screenshots: GuiScreenshotFile[] = [];
   const startTimeSeconds = Date.now() / 1000;
   let sampledMemoryBytes = 0;
-  // A submission can signal its own sandboxed `timeout` and then wedge the event loop (e.g.
-  // XGrabServer makes the synchronous `xwininfo`/`maim` block), so a harness-owned watchdog
-  // force-kills the sandbox user at the deadline; killing the client also releases its X grab.
-  const watchdog = startSandboxTimeoutWatchdog(context.timeLimitSeconds);
-
   child.stdout.on('data', (chunk: string) => {
     stdout += chunk;
   });
@@ -611,6 +619,7 @@ async function spawnGuiProgram(context: {
     // from the screenshots, so the watchdog must not overwrite it.
     const watchdogFired = stopReason === 'process_exit' && watchdog.fired();
     await stopProcess(child);
+    submissionStopped = true;
     if (spawnError) throw spawnError;
     const {
       memoryBytes,
@@ -629,7 +638,10 @@ async function spawnGuiProgram(context: {
       stopReason: watchdogFired ? 'timeout' : stopReason,
     };
   } finally {
-    watchdog.cancel();
+    // Only once the submission is demonstrably stopped: if termination itself failed (or never ran
+    // because a helper threw), the watchdog is the only thing left able to end it, and cancelling
+    // would leave it running unchecked.
+    if (submissionStopped) watchdog.cancel();
   }
 }
 

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -24,6 +24,7 @@ import {
   makeAccessibleToSandboxUser,
   sandboxUserName,
   startSandboxTimeoutWatchdog,
+  TIMEOUT_COMMAND,
   wrapCommandWithSandboxUser,
 } from '../helpers/sandboxUser.js';
 import { spawnSyncWithTimeout } from '../helpers/spawnSyncWithTimeout.js';
@@ -86,10 +87,24 @@ export interface GuiCommandJudgePresetOptions<TTestCase extends BaseGuiTestCase 
   readTestCases?: (problemDir: string) => Promise<readonly TTestCase[]>;
   prepare?: (context: {
     cwd: string;
+    /**
+     * Build the submission with it. Under `EXERCODE_SANDBOX_USER` delegation it already carries the
+     * sandbox user's overrides, but the handler must still wrap whatever it spawns with
+     * `wrapCommandWithSandboxUser` (both exported): a build runs the submission's own scripts
+     * (`package.json` lifecycle scripts, `build.gradle`, `build.rs`), which as the trusted harness
+     * user could read the problem's test cases and rewrite the harness. The preset terminates
+     * leftover sandbox processes after the handler returns.
+     */
     env: NodeJS.ProcessEnv;
     mainFilePath: string;
     problemMarkdownFrontMatter: ProblemMarkdownFrontMatter;
   }) => Promise<Partial<GuiJudgeCaseResult> | undefined> | Partial<GuiJudgeCaseResult> | undefined;
+  /**
+   * Runs as the trusted harness user with the submission's `cwd`. Fixture files it creates there
+   * must be written with `createDirectoryWithoutFollowingSymlinks`/`writeFileWithoutFollowingSymlinks`
+   * (both exported): a submission can plant a symlink at a fixture path, and a plain `fs.writeFile`
+   * would follow it into a file only the harness can write.
+   */
   resolveInput?: (context: { testCase: TTestCase; cwd: string; env: NodeJS.ProcessEnv }) => Promise<string> | string;
   command?: (context: {
     testCase: TTestCase;
@@ -231,12 +246,15 @@ export async function guiCommandJudgePreset<TTestCase extends BaseGuiTestCase = 
   }
 
   const prepareResult =
-    (await options.prepare?.({
-      cwd: args.cwd,
-      env,
-      mainFilePath: resolvedMainFilePath,
-      problemMarkdownFrontMatter,
-    })) ??
+    (options.prepare &&
+      (await runCustomRunner(() =>
+        options.prepare?.({
+          cwd: submissionDir,
+          env: { ...env, ...getSandboxUserEnvOverrides(env) },
+          mainFilePath: resolvedMainFilePath,
+          problemMarkdownFrontMatter,
+        })
+      ))) ??
     runDefaultPrepare({
       cwd: args.cwd,
       env,
@@ -499,7 +517,7 @@ async function spawnGuiProgram(context: {
   stopDetectionThreshold: number;
 }): Promise<GuiCommandRunResult> {
   const wrappedCommand = wrapCommandWithSandboxUser([
-    'timeout',
+    TIMEOUT_COMMAND,
     context.timeLimitSeconds.toFixed(3),
     ...TIME_COMMAND,
     ...context.command,

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -379,10 +379,15 @@ export async function guiCommandJudgePreset<TTestCase extends BaseGuiTestCase = 
     });
     await cleanWorkingDirectory(args.cwd, cwdSnapshot);
   } finally {
-    // Sweep any sandbox processes the run left behind (e.g. a SIGTERM-ignoring forked child) so they
-    // cannot race the harness's output reads or survive into the next test case/request.
-    if (sandboxUserName) killSandboxUserProcesses();
-    await displayServer?.dispose();
+    try {
+      // Sweep any sandbox processes the run left behind (e.g. a SIGTERM-ignoring forked child) so
+      // they cannot race the harness's output reads or survive into the next test case/request.
+      if (sandboxUserName) killSandboxUserProcesses();
+    } finally {
+      // Must run even when the sweep fails closed, or Xvfb keeps holding its display number and
+      // later GUI requests exhaust the `:90`–`:99` range.
+      await displayServer?.dispose();
+    }
   }
 }
 

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -19,6 +19,7 @@ import { readTestCases as readFileTestCases } from '../helpers/readTestCases.js'
 import {
   getSandboxUserEnvOverrides,
   killSandboxUserProcesses,
+  makeAccessibleToSandboxUser,
   sandboxUserName,
   wrapCommandWithSandboxUser,
 } from '../helpers/sandboxUser.js';
@@ -140,6 +141,9 @@ export async function guiCommandJudgePreset<TTestCase extends BaseGuiTestCase = 
   const args = parseArgs(process.argv);
   if (!args.cwd) throw new Error('cwd argument required');
   const params = judgeParamsSchema.parse(args.params);
+
+  // The sandboxed submission must read its sources and write build/run outputs in its directory.
+  makeAccessibleToSandboxUser(args.cwd);
 
   const problemMarkdownFrontMatter = await readProblemMarkdownFrontMatter(problemDir);
   const configuredTestCases = await (options.readTestCases ?? readGuiTestCases<TTestCase>)(problemDir);
@@ -474,7 +478,7 @@ async function spawnGuiProgram(context: {
   ]);
   const child = childProcess.spawn(wrappedCommand[0], wrappedCommand.slice(1), {
     cwd: context.cwd,
-    env: { ...context.env, ...getSandboxUserEnvOverrides() },
+    env: { ...context.env, ...getSandboxUserEnvOverrides(context.env) },
     detached: process.platform !== 'win32',
     stdio: ['pipe', 'pipe', 'pipe'],
   });
@@ -666,9 +670,12 @@ async function ensureDisplayServer(): Promise<{ display: string; dispose: () => 
 
 async function stopProcess(child: childProcess.ChildProcess): Promise<void> {
   if (!child.pid) return;
-  // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes.
+  // The current user cannot signal the root-owned sudo wrapper nor the sandbox user's processes,
+  // so go through sudo, keeping the same TERM → grace → KILL sequence as the direct path.
   if (sandboxUserName) {
-    killSandboxUserProcesses();
+    killSandboxUserProcesses(['TERM']);
+    await wait(PROCESS_SHUTDOWN_WAIT_SECONDS * 1000);
+    if (child.exitCode === null) killSandboxUserProcesses(['KILL']);
     return;
   }
   killProcessGroup(child.pid, 'SIGTERM');
@@ -679,7 +686,12 @@ async function stopProcess(child: childProcess.ChildProcess): Promise<void> {
 function readProcessGroupMemoryBytes(processGroupId: number | undefined): number {
   if (!processGroupId || process.platform !== 'linux') return 0;
 
-  const result = childProcess.spawnSync('ps', ['-o', 'rss=', '--no-headers', '--pgroup', String(processGroupId)], {
+  // Under delegation the child pid belongs to sudo, whose command may run in a different process
+  // group (sudo's use_pty mode calls setsid), so sample by user instead of by group there.
+  const psArgs = sandboxUserName
+    ? ['-o', 'rss=', '--no-headers', '-u', sandboxUserName]
+    : ['-o', 'rss=', '--no-headers', '--pgroup', String(processGroupId)];
+  const result = childProcess.spawnSync('/usr/bin/ps', psArgs, {
     encoding: 'utf8',
   });
   if (result.error || result.status !== 0 || !result.stdout) return 0;

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -585,9 +585,12 @@ async function spawnGuiProgram(context: {
     exitCode = code ?? 1;
   });
 
-  // Everything below must run under the watchdog's `finally`: `takeScreenshots` rethrows spawn
-  // failures (which a submission can provoke by exhausting PIDs), and a leaked watchdog is detached,
-  // so it would outlive the harness and SIGKILL a later request's submission.
+  // Everything below must run under the `finally` that decides the watchdog's fate: it is cancelled
+  // only once the submission is demonstrably stopped. When a helper throws first — `takeScreenshots`
+  // rethrows spawn failures, which a submission can provoke by exhausting PIDs — the watchdog stays
+  // armed on purpose, since nothing else would end the submission. The cost is that a detached
+  // watchdog can outlive this harness and SIGKILL sandbox processes of a request that starts within
+  // its remaining deadline, which is the same trade-off the package-manager runner accepts.
   try {
     if (context.stdin) child.stdin.write(context.stdin);
     child.stdin.end();

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -245,16 +245,30 @@ export async function guiCommandJudgePreset<TTestCase extends BaseGuiTestCase = 
     return;
   }
 
-  const prepareResult =
-    (options.prepare &&
-      (await runCustomRunner(() =>
+  let customPrepareResult: Partial<GuiJudgeCaseResult> | undefined;
+  if (options.prepare) {
+    try {
+      customPrepareResult = await runCustomRunner(() =>
         options.prepare?.({
           cwd: submissionDir,
           env: { ...env, ...getSandboxUserEnvOverrides(env) },
           mainFilePath: resolvedMainFilePath,
           problemMarkdownFrontMatter,
         })
-      ))) ??
+      );
+    } catch (error) {
+      // Like the `prebuild` step above: report the failed build rather than letting the throw (from
+      // the handler itself, or from the fail-closed sandbox sweep around it) end the run resultless.
+      printTestCaseResult({
+        testCaseId: prebuildTestCaseId,
+        decisionCode: DecisionCode.BUILD_ERROR,
+        stderr: errorToMessage(error),
+      });
+      return;
+    }
+  }
+  const prepareResult =
+    customPrepareResult ??
     runDefaultPrepare({
       cwd: args.cwd,
       env,

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -18,6 +18,7 @@ import { readProblemMarkdownFrontMatter } from '../helpers/readProblemMarkdownFr
 import { readTestCases as readFileTestCases } from '../helpers/readTestCases.js';
 import {
   getSandboxUserEnvOverrides,
+  getTrustedHelperEnv,
   killSandboxUserProcesses,
   makeAccessibleToSandboxUser,
   sandboxUserName,
@@ -97,6 +98,11 @@ export interface GuiCommandJudgePresetOptions<TTestCase extends BaseGuiTestCase 
   }) => Promise<readonly [string, ...string[]]> | readonly [string, ...string[]];
   runCommand?: (context: {
     testCase: TTestCase;
+    /**
+     * The command to run. Under `EXERCODE_SANDBOX_USER` delegation it is already wrapped so it
+     * executes as the sandbox user; spawn it as given (with the supplied `env`) instead of
+     * reconstructing it, or the submission runs as the trusted harness user.
+     */
     command: readonly [string, ...string[]];
     stdin: string;
     cwd: string;
@@ -271,10 +277,13 @@ export async function guiCommandJudgePreset<TTestCase extends BaseGuiTestCase = 
         runResult = options.runCommand
           ? await options.runCommand({
               testCase,
-              command,
+              // Hand custom runners a command that is already sandbox-wrapped, and the matching
+              // environment: they spawn it themselves, so an unwrapped command would run the
+              // submission as the trusted harness user and defeat the delegation boundary.
+              command: wrapCommandWithSandboxUser(command),
               stdin,
               cwd: args.cwd,
-              env: runEnv,
+              env: { ...runEnv, ...getSandboxUserEnvOverrides(runEnv) },
               timeLimitSeconds,
               screenshotWaitSeconds: options.screenshotWaitSeconds ?? SCREENSHOT_WAIT_SECONDS,
               stopDetectionThreshold: options.stopDetectionThreshold ?? STOP_DETECTION_THRESHOLD,
@@ -502,7 +511,7 @@ async function spawnGuiProgram(context: {
   // A submission can signal its own sandboxed `timeout` and then wedge the event loop (e.g.
   // XGrabServer makes the synchronous `xwininfo`/`maim` block), so a harness-owned watchdog
   // force-kills the sandbox user at the deadline; killing the client also releases its X grab.
-  const stopWatchdog = startSandboxTimeoutWatchdog(context.timeLimitSeconds);
+  const watchdog = startSandboxTimeoutWatchdog(context.timeLimitSeconds);
 
   child.stdout.on('data', (chunk: string) => {
     stdout += chunk;
@@ -513,6 +522,11 @@ async function spawnGuiProgram(context: {
   child.on('error', (error) => {
     spawnError = error;
     exitCode = 1;
+  });
+  // A child that exits before the input is fully written makes the write fail; without a listener
+  // that EPIPE would be an unhandled stream error terminating the harness mid-run.
+  child.stdin.on('error', () => {
+    // The submission simply stopped reading its input; the exit handling below reports the result.
   });
   child.on('close', (code, signal) => {
     if (code === 124) {
@@ -530,67 +544,78 @@ async function spawnGuiProgram(context: {
     exitCode = code ?? 1;
   });
 
-  if (context.stdin) child.stdin.write(context.stdin);
-  child.stdin.end();
+  // Everything below must run under the watchdog's `finally`: `takeScreenshots` rethrows spawn
+  // failures (which a submission can provoke by exhausting PIDs), and a leaked watchdog is detached,
+  // so it would outlive the harness and SIGKILL a later request's submission.
+  try {
+    if (context.stdin) child.stdin.write(context.stdin);
+    child.stdin.end();
 
-  while (exitCode === undefined) {
-    await wait(context.screenshotWaitSeconds * 1000);
-    sampledMemoryBytes = Math.max(sampledMemoryBytes, readProcessGroupMemoryBytes(child.pid));
-    const currentScreenshots = takeScreenshots(context.env.DISPLAY);
-    screenshots = currentScreenshots.toSorted((a, b) => a.data.length - b.data.length);
+    while (exitCode === undefined) {
+      await wait(context.screenshotWaitSeconds * 1000);
+      sampledMemoryBytes = Math.max(sampledMemoryBytes, readProcessGroupMemoryBytes(child.pid));
+      const currentScreenshots = takeScreenshots(context.env.DISPLAY);
+      screenshots = currentScreenshots.toSorted((a, b) => a.data.length - b.data.length);
 
-    if (screenshots.length > 0) {
-      const screenshotSignatures = screenshots.map((file) => file.data).toSorted();
-      screenshotSignaturesHistory.unshift(screenshotSignatures);
-      screenshotSignaturesHistory.length = Math.min(screenshotSignaturesHistory.length, context.stopDetectionThreshold);
-      if (
-        screenshotSignaturesHistory.length === context.stopDetectionThreshold &&
-        screenshotSignaturesHistory.every(
-          (files) =>
-            files.length === screenshotSignatures.length &&
-            files.every((file, index) => file === screenshotSignatures[index])
-        )
-      ) {
-        stopReason = 'stable_screenshot';
+      if (screenshots.length > 0) {
+        const screenshotSignatures = screenshots.map((file) => file.data).toSorted();
+        screenshotSignaturesHistory.unshift(screenshotSignatures);
+        screenshotSignaturesHistory.length = Math.min(
+          screenshotSignaturesHistory.length,
+          context.stopDetectionThreshold
+        );
+        if (
+          screenshotSignaturesHistory.length === context.stopDetectionThreshold &&
+          screenshotSignaturesHistory.every(
+            (files) =>
+              files.length === screenshotSignatures.length &&
+              files.every((file, index) => file === screenshotSignatures[index])
+          )
+        ) {
+          stopReason = 'stable_screenshot';
+          exitCode = 0;
+          break;
+        }
+      }
+
+      if (Date.now() / 1000 - startTimeSeconds > context.timeLimitSeconds) {
+        stopReason = 'timeout';
         exitCode = 0;
         break;
       }
     }
 
-    if (Date.now() / 1000 - startTimeSeconds > context.timeLimitSeconds) {
-      stopReason = 'timeout';
-      exitCode = 0;
-      break;
+    if (stopReason !== 'process_exit' && child.exitCode === null) {
+      child.removeAllListeners('close');
+      child.removeAllListeners('error');
     }
-  }
+    await stopProcess(child);
+    if (spawnError) throw spawnError;
+    const {
+      memoryBytes,
+      stderr: normalizedStderr,
+      timeSeconds,
+    } = parseTimedStderr(stderr, startTimeSeconds, sampledMemoryBytes);
 
-  if (stopReason !== 'process_exit' && child.exitCode === null) {
-    child.removeAllListeners('close');
-    child.removeAllListeners('error');
+    return {
+      stdin: context.stdin,
+      stdout: stdout.trimEnd(),
+      stderr: normalizedStderr,
+      status: exitCode,
+      timeSeconds,
+      memoryBytes,
+      screenshots,
+      stopReason,
+    };
+  } finally {
+    watchdog.cancel();
   }
-  await stopProcess(child);
-  stopWatchdog();
-  if (spawnError) throw spawnError;
-  const {
-    memoryBytes,
-    stderr: normalizedStderr,
-    timeSeconds,
-  } = parseTimedStderr(stderr, startTimeSeconds, sampledMemoryBytes);
-
-  return {
-    stdin: context.stdin,
-    stdout: stdout.trimEnd(),
-    stderr: normalizedStderr,
-    status: exitCode,
-    timeSeconds,
-    memoryBytes,
-    screenshots,
-    stopReason,
-  };
 }
 
 function takeScreenshots(display: string | undefined): GuiScreenshotFile[] {
-  const env = display ? { ...process.env, DISPLAY: display } : process.env;
+  // These helpers run as the trusted harness user, so they must not be resolved through a
+  // submission-influenced `PATH` (see `getTrustedHelperEnv`).
+  const env = getTrustedHelperEnv(display ? { DISPLAY: display } : { DISPLAY: process.env.DISPLAY });
   const xwininfo = childProcess.spawnSync('xwininfo', ['-root', '-tree'], { encoding: 'utf8', env });
   if (xwininfo.error) throw xwininfo.error;
   if (xwininfo.status !== 0 || !xwininfo.stdout) return [];
@@ -653,6 +678,8 @@ async function ensureDisplayServer(): Promise<{ display: string; dispose: () => 
     let spawnError: Error | undefined;
     const xvfb = childProcess.spawn('Xvfb', [display, '-screen', '0', '1280x1024x24', '-ac'], {
       stdio: 'ignore',
+      // Runs as the trusted harness user, so pin the lookup to system paths.
+      env: getTrustedHelperEnv(),
     });
     xvfb.on('error', (error) => {
       spawnError = error;
@@ -700,6 +727,8 @@ function readProcessGroupMemoryBytes(processGroupId: number | undefined): number
   // stays in the detached child's process group; `--pgroup` therefore still captures it there.
   const result = childProcess.spawnSync('ps', ['-o', 'rss=', '--no-headers', '--pgroup', String(processGroupId)], {
     encoding: 'utf8',
+    // Runs as the trusted harness user, so pin the lookup to system paths.
+    env: getTrustedHelperEnv(),
   });
   if (result.error || result.status !== 0 || !result.stdout) return 0;
 

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -16,6 +16,7 @@ import { printTestCaseResult } from '../helpers/printTestCaseResult.js';
 import { readOutputFiles } from '../helpers/readOutputFiles.js';
 import { readProblemMarkdownFrontMatter } from '../helpers/readProblemMarkdownFrontMatter.js';
 import { readTestCases as readFileTestCases } from '../helpers/readTestCases.js';
+import { runCustomRunner } from '../helpers/runCustomRunner.js';
 import {
   getSandboxUserEnvOverrides,
   getTrustedHelperEnv,
@@ -102,6 +103,11 @@ export interface GuiCommandJudgePresetOptions<TTestCase extends BaseGuiTestCase 
      * The command to run. Under `EXERCODE_SANDBOX_USER` delegation it is already wrapped so it
      * executes as the sandbox user; spawn it as given (with the supplied `env`) instead of
      * reconstructing it, or the submission runs as the trusted harness user.
+     *
+     * Its direct child is then a root-owned `sudo` whose descendants belong to the sandbox user, so
+     * the handler cannot signal them: enforce `timeLimitSeconds` with `startSandboxTimeoutWatchdog`
+     * and `killSandboxUserProcesses` (both exported) rather than `child.kill()` or an outer
+     * `timeout`. The preset terminates leftover sandbox processes after the handler returns.
      */
     command: readonly [string, ...string[]];
     stdin: string;
@@ -148,9 +154,10 @@ export async function guiCommandJudgePreset<TTestCase extends BaseGuiTestCase = 
   const args = parseArgs(process.argv);
   if (!args.cwd) throw new Error('cwd argument required');
   const params = judgeParamsSchema.parse(args.params);
+  const submissionDir = args.cwd;
 
   // The sandboxed submission must read its sources and write build/run outputs in its directory.
-  makeAccessibleToSandboxUser(args.cwd);
+  makeAccessibleToSandboxUser(submissionDir);
 
   const problemMarkdownFrontMatter = await readProblemMarkdownFrontMatter(problemDir);
   const configuredTestCases = await (options.readTestCases ?? readGuiTestCases<TTestCase>)(problemDir);
@@ -275,19 +282,22 @@ export async function guiCommandJudgePreset<TTestCase extends BaseGuiTestCase = 
       let runResult: GuiCommandRunResult;
       try {
         runResult = options.runCommand
-          ? await options.runCommand({
-              testCase,
-              // Hand custom runners a command that is already sandbox-wrapped, and the matching
-              // environment: they spawn it themselves, so an unwrapped command would run the
-              // submission as the trusted harness user and defeat the delegation boundary.
-              command: wrapCommandWithSandboxUser(command),
-              stdin,
-              cwd: args.cwd,
-              env: { ...runEnv, ...getSandboxUserEnvOverrides(runEnv) },
-              timeLimitSeconds,
-              screenshotWaitSeconds: options.screenshotWaitSeconds ?? SCREENSHOT_WAIT_SECONDS,
-              stopDetectionThreshold: options.stopDetectionThreshold ?? STOP_DETECTION_THRESHOLD,
-            })
+          ? await runCustomRunner(
+              () =>
+                // Hand custom runners a command that is already sandbox-wrapped, and the matching
+                // environment: they spawn it themselves, so an unwrapped command would run the
+                // submission as the trusted harness user and defeat the delegation boundary.
+                options.runCommand?.({
+                  testCase,
+                  command: wrapCommandWithSandboxUser(command),
+                  stdin,
+                  cwd: submissionDir,
+                  env: { ...runEnv, ...getSandboxUserEnvOverrides(runEnv) },
+                  timeLimitSeconds,
+                  screenshotWaitSeconds: options.screenshotWaitSeconds ?? SCREENSHOT_WAIT_SECONDS,
+                  stopDetectionThreshold: options.stopDetectionThreshold ?? STOP_DETECTION_THRESHOLD,
+                }) as Promise<GuiCommandRunResult>
+            )
           : await spawnGuiProgram({
               command,
               stdin,

--- a/src/presets/guiCommand.ts
+++ b/src/presets/guiCommand.ts
@@ -604,6 +604,10 @@ async function spawnGuiProgram(context: {
       child.removeAllListeners('close');
       child.removeAllListeners('error');
     }
+    // A submission can kill its own same-UID `timeout` and be stopped by the watchdog instead,
+    // which surfaces as a SIGKILL rather than a deadline. Report that as the timeout it is, not as
+    // the runtime error the signal would otherwise imply.
+    const watchdogFired = watchdog.fired();
     await stopProcess(child);
     if (spawnError) throw spawnError;
     const {
@@ -616,11 +620,11 @@ async function spawnGuiProgram(context: {
       stdin: context.stdin,
       stdout: stdout.trimEnd(),
       stderr: normalizedStderr,
-      status: exitCode,
+      status: watchdogFired ? 0 : exitCode,
       timeSeconds,
       memoryBytes,
       screenshots,
-      stopReason,
+      stopReason: watchdogFired ? 'timeout' : stopReason,
     };
   } finally {
     watchdog.cancel();

--- a/src/presets/stdio.ts
+++ b/src/presets/stdio.ts
@@ -11,7 +11,8 @@ import { findLanguageDefinitionByPath } from '../helpers/findLanguageDefinitionB
 import { judgeByStaticAnalysis } from '../helpers/judgeByStaticAnalysis.js';
 import { parseArgs } from '../helpers/parseArgs.js';
 import { printTestCaseResult } from '../helpers/printTestCaseResult.js';
-import { readOutputFiles } from '../helpers/readOutputFiles.js';
+import { isSafeSubmissionOutputPath, readOutputFiles } from '../helpers/readOutputFiles.js';
+import { makeAccessibleToSandboxUser } from '../helpers/sandboxUser.js';
 import { readProblemMarkdownFrontMatter } from '../helpers/readProblemMarkdownFrontMatter.js';
 import { readTestCases } from '../helpers/readTestCases.js';
 import { spawnSyncWithTimeout } from '../helpers/spawnSyncWithTimeout.js';
@@ -56,6 +57,9 @@ export async function stdioJudgePreset(problemDir: string): Promise<void> {
   const args = parseArgs(process.argv);
   if (!args.cwd) throw new Error('cwd argument required');
   const params = judgeParamsSchema.parse(args.params);
+
+  // The sandboxed submission must read its sources and write build/run outputs in its directory.
+  makeAccessibleToSandboxUser(args.cwd);
 
   const problemMarkdownFrontMatter = await readProblemMarkdownFrontMatter(problemDir);
   const testCases = await readTestCases(path.join(problemDir, 'test_cases'));
@@ -207,7 +211,10 @@ export async function stdioJudgePreset(problemDir: string): Promise<void> {
         const direntRelativePath = path.relative(testCase.fileOutputPath, dirent.parentPath);
         const expected = await fs.promises.readFile(path.join(dirent.parentPath, dirent.name));
         try {
-          const received = await fs.promises.readFile(path.join(args.cwd, direntRelativePath, dirent.name));
+          const receivedPath = path.join(args.cwd, direntRelativePath, dirent.name);
+          // A submission-planted symlink to the expected file itself would otherwise compare equal.
+          if (!(await isSafeSubmissionOutputPath(args.cwd, receivedPath))) throw new Error('unsafe output path');
+          const received = await fs.promises.readFile(receivedPath);
           if (received.compare(expected) !== 0) decisionCode = DecisionCode.WRONG_ANSWER;
         } catch (error) {
           console.error(error);
@@ -255,6 +262,9 @@ export async function stdioDebugPreset(problemDir: string): Promise<void> {
   const args = parseArgs(process.argv);
   if (!args.cwd) throw new Error('cwd argument required');
   const params = debugParamsSchema.parse(args.params);
+
+  // The sandboxed submission must read its sources and write build/run outputs in its directory.
+  makeAccessibleToSandboxUser(args.cwd);
 
   const problemMarkdownFrontMatter = await readProblemMarkdownFrontMatter(problemDir);
 

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { removeCommentsInSourceCode } from '../helpers/removeCommentsInSourceCode.js';
+import { writeFileWithoutFollowingSymlinks } from '../helpers/safeFs.js';
 
 export interface LanguageDefinition {
   /** File extensions to judge with this config. */
@@ -58,7 +59,9 @@ export const languageIdToDefinition: Readonly<Record<string, Readonly<LanguageDe
   csharp: {
     fileExtensions: ['.cs'],
     prebuild: async (cwd) => {
-      await fs.promises.writeFile(
+      // No-follow write: the submission owns `cwd` and could point `Main.csproj` at a file only the
+      // trusted harness user can write.
+      await writeFileWithoutFollowingSymlinks(
         path.join(cwd, 'Main.csproj'),
         `<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>


### PR DESCRIPTION
## Customer Summary

判定サーバーが「採点ハーネス」と「提出プログラム」を別々の OS ユーザーで動かせるようになります。これまで両者は同じユーザーで動いていたため、提出プログラムから問題ディレクトリ (`test_cases` の期待出力やハーネス自身) を読み書きできてしまいました (WillBooster/judge#2101、#2100)。

- 環境変数 `EXERCODE_SANDBOX_USER` を設定した場合のみ有効になります。未設定のとき (ローカル開発・教材作成・従来の全 sandbox 実行) の挙動は従来と完全に同一です。
- 委譲は Linux 限定の契約です (sudo のユーザー分離と `/home/<user>` は judge の Docker イメージで用意されます)。macOS では設定しません。
- 問題作成者への影響: 独自の `runCommand` / `prepare` / `resolveInput` を書く場合は、渡されたコマンドをそのまま起動し、ファイル作成には新しい no-follow ヘルパーを使う必要があります (各オプションの JSDoc に明記)。

## Technical Summary

`helpers/sandboxUser.ts` (新規) が委譲の中核です。`SANDBOX_USER_ENV_NAME` / `SANDBOX_ENV_PREFIX` を契約定数としてエクスポートし、sudo ラッパー (`umask 0`、setuid exec で剥がされる `LD_LIBRARY_PATH` の復元)、sandbox 用環境変数、`chmod` / `pkill` / 強制削除ヘルパー、ハーネス所有のタイムアウト watchdog を提供します。

- **実行経路**: `spawnSyncWithTimeout`、`runCommandInTemporaryPackageManagerProject`、`guiCommand` の起動・停止、そしてカスタム `runCommand` / GUI `prepare` (いずれも `runCustomRunner` 経由で後始末) が sandbox ユーザーで動きます。`timeout` はラッパーの内側に置き、委譲時は絶対パスで解決します (ハーネスユーザーは root 所有の sudo にシグナルを送れないため、また提出側の `PATH` で差し替えられないため)。
- **環境変数**: 判定サーバーは提出プログラム向けの変数を `SANDBOX_ENV_` 付きで渡し、`getSandboxUserEnvOverrides` が sandbox 用環境を組み立てる際に外します。ハーネス自身が `PATH` や `NODE_OPTIONS` で乗っ取られないようにするためです。信頼ユーザーが起動するヘルパー (`ps`、`xwininfo`、`Xvfb` など) は固定 `PATH` で解決します。
- **ファイル境界**: 信頼ユーザーの読み書きが提出物の仕込んだシンボリックリンクをたどらないよう、`helpers/safeFs.ts` (新規) の `copyWithoutFollowingSymlinks` / `createDirectoryWithoutFollowingSymlinks` / `writeFileWithoutFollowingSymlinks` / `isContainedPath` を用意し、テストケース入力のコピー、パッケージマネージャのプロジェクトファイル重ね合わせ、C# の `Main.csproj` 生成、出力ファイルの読み取り、`startHttpServer` の配信に適用しました。作業ディレクトリのスナップショットはエントリ種別を保持し、種別が変わったものを削除します。
- **プロセス終了**: 提出物が PID cgroup を枯渇させても期限を守れるよう、watchdog は提出プロセスの起動前に張り、終了を確認できた場合にのみ取り消します。sweep は fail-closed です。
- **既知の限界**: 終了手段が依然として新規プロセス生成 (`sudo pkill`) に依存するため、PID 枯渇下では取りこぼし得ます → #306。setuid exec は glibc の secure-execution mode により `TMPDIR` などを削ぎ落とすため、復元しているのは `LD_LIBRARY_PATH` のみです (契約 JSDoc に明記)。

## Testing

- `bun run verify` / `bun run build` / `bun run test` (e2e 21 件) — いずれも成功。
- 主要な不変条件は実行して確認しました: `SANDBOX_ENV_` の展開と `LD_LIBRARY_PATH` の受け渡し、シンボリックリンクを張った宛先・親ディレクトリ・fixture への書き込み、スナップショット種別変化の掃除、`startHttpServer` の封じ込め、固定 `PATH`、プロジェクトファイル重ね合わせの順序。
- Codex / Claude Code / Antigravity による多ラウンドのレビューで指摘された点を反映済みです。

## Related

- WillBooster/judge#2101 / WillBooster/judge#2100 を解消する judge 側 PR (WillBooster/judge#2103) がこのリリースに依存します。
- 残課題: WillBooster/exercode-problem-utils#306
