### PR TITLE
feat!: rename the CLI bin from `exercode` to `exercode-problem`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@
 
 ## CLI
 
-The package ships an `exercode` command for problem authors (run it with `bun x` in a repository that depends on `@exercode/problem-utils`):
+The package ships an `exercode-problem` command for problem authors (run it with `bun x` in a repository that depends on `@exercode/problem-utils`):
 
 ```bash
 # Judge all model answers of all problems (directories containing problem.md or <id>.problem.md) under a directory.
 # model_answers/* must be fully accepted; model_answers.fails/* must fail at least one test case.
-bun x exercode                # everything under the current directory
-bun x exercode courses/foo    # everything under courses/foo
-bun x exercode --only a_plus --skip gui_ --concurrency 2
+bun x exercode-problem                # everything under the current directory
+bun x exercode-problem courses/foo    # everything under courses/foo
+bun x exercode-problem --only a_plus --skip gui_ --concurrency 2
 
 # Judge one answer directory of the problem in the current directory.
-bun x exercode judge model_answers/python
-bun x exercode judge model_answers/python '{ "language": "python" }'
+bun x exercode-problem judge model_answers/python
+bun x exercode-problem judge model_answers/python '{ "language": "python" }'
 
 # Debug one answer directory of the problem in the current directory.
-bun x exercode debug model_answers/python '{ "stdin": "1 2" }'
+bun x exercode-problem debug model_answers/python '{ "stdin": "1 2" }'
 ```
 
-`judge` and `debug` run a custom `judge.ts` / `debug.ts` when the problem has one, and apply `stdioJudgePreset` / `stdioDebugPreset` otherwise, mirroring the Exercode server. The debug fallback applies only to standard problems: a problem with a custom `judge.ts` needs its own `debug.ts`, and `exercode debug` fails with a message otherwise (the server likewise reports debug as unsupported there).
+`judge` and `debug` run a custom `judge.ts` / `debug.ts` when the problem has one, and apply `stdioJudgePreset` / `stdioDebugPreset` otherwise, mirroring the Exercode server. The debug fallback applies only to standard problems: a problem with a custom `judge.ts` needs its own `debug.ts`, and `exercode-problem debug` fails with a message otherwise (the server likewise reports debug as unsupported there).
 
 The all-problem check judges serially by default because time limits are measured in wall-clock time; pass `--concurrency <n>` to parallelize when the checked problems are not timing-sensitive.
 

--- a/bin/exercode-problem.mjs
+++ b/bin/exercode-problem.mjs
@@ -1,0 +1,2 @@
+#!/usr/bin/env bun
+import '../dist/cli/exercodeProblem.js';

--- a/bin/exercode.mjs
+++ b/bin/exercode.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env bun
-import '../dist/cli/exercode.js';

--- a/example/a_plus_b/debug.ts
+++ b/example/a_plus_b/debug.ts
@@ -1,6 +1,6 @@
 // This file demonstrates what the Exercode server runs for a problem without debug.ts.
 // A real standard stdio problem must NOT commit this file; this comment marks it as custom
-// so that the exercode CLI does not reject it as a copy of the default harness.
+// so that the exercode-problem CLI does not reject it as a copy of the default harness.
 import { stdioDebugPreset } from '@exercode/problem-utils/presets/stdio';
 
 await stdioDebugPreset(import.meta.dirname);

--- a/example/a_plus_b/judge.ts
+++ b/example/a_plus_b/judge.ts
@@ -1,6 +1,6 @@
 // This file demonstrates what the Exercode server runs for a problem without judge.ts.
 // A real standard stdio problem must NOT commit this file; this comment marks it as custom
-// so that the exercode CLI does not reject it as a copy of the default harness.
+// so that the exercode-problem CLI does not reject it as a copy of the default harness.
 import { stdioJudgePreset } from '@exercode/problem-utils/presets/stdio';
 
 await stdioJudgePreset(import.meta.dirname);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "exercode": "bin/exercode.mjs"
+    "exercode-problem": "bin/exercode-problem.mjs"
   },
   "files": [
     "bin/",

--- a/src/cli/exercodeProblem.ts
+++ b/src/cli/exercodeProblem.ts
@@ -1,14 +1,14 @@
 import { checkAllProblems } from './checkAllProblems.js';
 import { runSingleHarness } from './runSingleHarness.js';
 
-const usage = `Usage: exercode [rootDir] [--only <substring>]... [--skip <substring>]... [--concurrency <n>]
-       exercode judge <answerDir> [paramsJson]
-       exercode debug <answerDir> [paramsJson]
+const usage = `Usage: exercode-problem [rootDir] [--only <substring>]... [--skip <substring>]... [--concurrency <n>]
+       exercode-problem judge <answerDir> [paramsJson]
+       exercode-problem debug <answerDir> [paramsJson]
 
 Without a subcommand, judge all model answers of all problems under rootDir
 (default: the current directory). Use \`judge\` or \`debug\` in a problem
 directory to run one answer directory, e.g.:
-  exercode debug model_answers/python '{ "stdin": "1 2" }'`;
+  exercode-problem debug model_answers/python '{ "stdin": "1 2" }'`;
 
 // oxlint-disable-next-line unicorn/prefer-top-level-await -- the CJS build output does not support top-level await
 void main();

--- a/src/cli/runSingleHarness.ts
+++ b/src/cli/runSingleHarness.ts
@@ -67,6 +67,6 @@ export function formatDefaultHarnessError(defaultHarnessFileNames: readonly stri
   const fileNames = defaultHarnessFileNames.join(' and ');
   return `${fileNames} must not be committed because the content is identical to the default stdio harness.
 A problem without judge.ts is automatically judged with stdioJudgePreset and debugged with stdioDebugPreset,
-so delete ${fileNames} and run the problem with \`bun x exercode judge <answerDir>\` or \`bun x exercode debug <answerDir>\`.
+so delete ${fileNames} and run the problem with \`bun x exercode-problem judge <answerDir>\` or \`bun x exercode-problem debug <answerDir>\`.
 If the file intentionally demonstrates the default harness, add an explanatory comment to mark it as custom.`;
 }

--- a/src/presets/stdio.ts
+++ b/src/presets/stdio.ts
@@ -42,12 +42,12 @@ const debugParamsSchema = judgeParamsSchema.extend({
  * @example
  * Run in a problem directory without `judge.ts`:
  * ```bash
- * bun x exercode judge model_answers/java
+ * bun x exercode-problem judge model_answers/java
  * ```
  *
  * Run with the optional parameters:
  * ```bash
- * bun x exercode judge model_answers/java '{ "language": "javascript" }'
+ * bun x exercode-problem judge model_answers/java '{ "language": "javascript" }'
  * ```
  */
 export async function stdioJudgePreset(problemDir: string): Promise<void> {
@@ -249,7 +249,7 @@ export async function stdioJudgePreset(problemDir: string): Promise<void> {
  * @example
  * Run in a problem directory without `debug.ts`:
  * ```bash
- * bun x exercode debug model_answers/java '{ "stdin": "1 2" }'
+ * bun x exercode-problem debug model_answers/java '{ "stdin": "1 2" }'
  * ```
  */
 export async function stdioDebugPreset(problemDir: string): Promise<void> {

--- a/test/e2e/checkCli.test.ts
+++ b/test/e2e/checkCli.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { afterAll, expect, test } from 'vitest';
 
-const cliPath = path.resolve('src/cli/exercode.ts');
+const cliPath = path.resolve('src/cli/exercodeProblem.ts');
 
 const tempRoots: string[] = [];
 afterAll(async () => {

--- a/test/e2e/debugAndJudge.test.ts
+++ b/test/e2e/debugAndJudge.test.ts
@@ -297,10 +297,10 @@ test.each<
     ],
   ],
 
-  // a_plus_b_file has no judge.ts, so the exercode CLI's judge subcommand applies stdioJudgePreset (like the server).
+  // a_plus_b_file has no judge.ts, so the exercode-problem CLI's judge subcommand applies stdioJudgePreset (like the server).
   [
     'example/a_plus_b_file',
-    '../../src/cli/exercode.ts judge',
+    '../../src/cli/exercodeProblem.ts judge',
     'model_answers/javascript',
     {},
     {},
@@ -308,7 +308,7 @@ test.each<
   ],
   [
     'example/a_plus_b_file',
-    '../../src/cli/exercode.ts judge',
+    '../../src/cli/exercodeProblem.ts judge',
     'model_answers.test/javascript_mrofe',
     {},
     {},
@@ -325,7 +325,7 @@ test.each<
   ],
   [
     'example/a_plus_b_file',
-    '../../src/cli/exercode.ts judge',
+    '../../src/cli/exercodeProblem.ts judge',
     'model_answers.test/javascript_wa',
     {},
     {},
@@ -473,7 +473,7 @@ test.each<
     const tempDir = await fs.promises.mkdtemp(path.join('temp', 'judge_'));
     await fs.promises.cp(cwd, tempDir, { recursive: true });
 
-    // scriptFilename may carry a CLI subcommand (e.g. "../../src/cli/exercode.ts judge").
+    // scriptFilename may carry a CLI subcommand (e.g. "../../src/cli/exercodeProblem.ts judge").
     const spawnResult = child_process.spawnSync(
       'bun',
       ['run', ...scriptFilename.split(' '), argsCwd, JSON.stringify(argsParams)],


### PR DESCRIPTION
## Summary

- Rename the installed CLI command from `exercode` to `exercode-problem`, keeping the top-level `exercode` name free for a future platform-wide CLI.
- Rename `bin/exercode.mjs` → `bin/exercode-problem.mjs` and `src/cli/exercode.ts` → `src/cli/exercodeProblem.ts`.
- Update all usage strings, docs (README, preset JSDoc), example comments, and E2E tests accordingly.

## Notes

This is a breaking change for anyone invoking `bun x exercode ...`; the versions that shipped the old bin (1.19.0 and 1.20.0) are still within npm's 72-hour unpublish window if we want to remove them.

## Verification

`bun run verify-full` passed locally (exit 0).
