### PR TITLE
fix: verify that sandbox processes are gone instead of trusting pkill's status

### DIFF
--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -190,38 +190,41 @@ export function killSandboxUserProcesses(signals: readonly ('TERM' | 'KILL')[] =
   if (!sandboxUserName) return;
   // One direct call per signal instead of one `sh -c 'pkill ...; pkill ...'`: the wrapping shell
   // would run as the sandbox user too, so the first pkill would kill it before the second ran.
-  // Failures are collected instead of thrown mid-loop so a failed SIGTERM sweep never skips the
-  // unconditional SIGKILL sweep.
-  const failures: string[] = [];
+  // Their results are not inspected: `sudo` exits with 1 both when `pkill` matched nothing and on
+  // its own failures, and a sweep can itself be killed by a concurrent watchdog sweep
+  // ({@link startSandboxTimeoutWatchdog}'s `pkill -KILL` matches it). What matters is the outcome.
   for (const signal of signals) {
-    const firstFailure = sweepSandboxUserProcessesOnce(signal);
-    const failure = firstFailure ? sweepSandboxUserProcessesOnce(signal) : undefined;
-    if (failure) failures.push(`pkill -${signal}: ${failure}`);
+    runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName]);
   }
-  // Fail closed: a submission can exhaust the PID cgroup so this `sudo` cannot even be spawned,
-  // and a spawned `sudo` can still fail to run `pkill` (e.g. fork failure inside sudo).
-  // Reporting success would leave its processes alive for the next request on this instance.
-  if (failures.length > 0) {
-    throw new Error(`failed to terminate ${sandboxUserName} processes: ${failures.join('; ')}`);
-  }
+  // Fail closed once SIGKILL was sent: a submission can exhaust the PID cgroup so the `sudo` above
+  // cannot even be spawned, and reporting success would leave its processes alive for the next
+  // request on this instance. After SIGTERM alone, survivors are expected (the caller grants a
+  // grace period before sending SIGKILL).
+  if (!signals.includes('KILL')) return;
+  const survivors = findSurvivingSandboxUserProcesses();
+  if (survivors) throw new Error(`failed to terminate ${sandboxUserName} processes: ${survivors}`);
 }
 
 /**
- * Runs one `pkill` sweep and returns a failure description, or `undefined` on success. Retried once
- * by the caller because a sweep can itself be killed by a concurrent watchdog sweep
- * ({@link startSandboxTimeoutWatchdog}'s `pkill -KILL` matches it).
+ * Lists the sandbox user's live processes as the harness user (listing needs no privilege), or
+ * `undefined` when none remain. Just-killed processes linger as zombies until reaped, so those are
+ * ignored and the check is retried briefly.
  */
-function sweepSandboxUserProcessesOnce(signal: 'TERM' | 'KILL'): string | undefined {
-  const result = runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName as string]);
-  if (result.error) return result.error.message;
-  if (result.status === null) return `terminated by ${result.signal ?? 'an unknown signal'}`;
-  if (result.status === 0) return undefined;
-  // `sudo` exits with 1 both when `pkill` matched no process (a success, silent on stderr) and on
-  // its own failures (auth/permission problems, fork/exec failure — all reported on stderr), so
-  // status alone cannot distinguish them.
-  const stderr = result.stderr.toString().trim();
-  if (result.status === 1 && !stderr) return undefined;
-  return `exit status ${result.status}${stderr ? ` (${stderr})` : ''}`;
+function findSurvivingSandboxUserProcesses(): string | undefined {
+  for (let attempt = 0; ; attempt++) {
+    const result = child_process.spawnSync('ps', ['-o', 'pid=,stat=,comm=', '-u', sandboxUserName as string], {
+      env: MINIMAL_ENV,
+      encoding: 'utf8',
+    });
+    if (result.error) return `cannot list processes: ${result.error.message}`;
+    const survivors = result.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line && !/^\d+\s+Z/.test(line));
+    if (survivors.length === 0) return undefined;
+    if (attempt >= 5) return survivors.join(', ');
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+  }
 }
 
 /**

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -186,9 +186,10 @@ export function makeAccessibleToSandboxUser(targetPath: string): void {
  * sends SIGTERM immediately followed by SIGKILL (final cleanup); callers that want a grace period
  * send `['TERM']`, wait, and then send `['KILL']`.
  *
- * Fails closed: after SIGKILL, throws when a sandbox process is still alive (e.g. a submission
- * exhausted the PID cgroup so `sudo` cannot spawn). Reporting success would leave that process
- * running next to the next request on this instance.
+ * Fails closed: a `['TERM']`-only sweep throws when its `sudo` could not be spawned (e.g. a
+ * submission exhausted the PID cgroup); a sweep including SIGKILL throws when a sandbox process is
+ * still alive, or cannot be listed, afterwards. Reporting success would leave that process running
+ * next to the next request on this instance.
  */
 export function killSandboxUserProcesses(signals: readonly ('TERM' | 'KILL')[] = ['TERM', 'KILL']): void {
   if (!sandboxUserName) return;

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -190,19 +190,38 @@ export function killSandboxUserProcesses(signals: readonly ('TERM' | 'KILL')[] =
   if (!sandboxUserName) return;
   // One direct call per signal instead of one `sh -c 'pkill ...; pkill ...'`: the wrapping shell
   // would run as the sandbox user too, so the first pkill would kill it before the second ran.
+  // Failures are collected instead of thrown mid-loop so a failed SIGTERM sweep never skips the
+  // unconditional SIGKILL sweep.
+  const failures: string[] = [];
   for (const signal of signals) {
-    const result = runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName]);
-    // Fail closed: a submission can exhaust the PID cgroup so this `sudo` cannot even be spawned,
-    // and a spawned `sudo` can still fail to run `pkill` (e.g. fork failure inside sudo).
-    // Reporting success would leave its processes alive for the next request on this instance.
-    // `pkill` exits with 1 when no process matched, which is a success here.
-    if (result.error) {
-      throw new Error(`failed to terminate ${sandboxUserName} processes: ${result.error.message}`);
-    }
-    if (result.status !== 0 && result.status !== 1) {
-      throw new Error(`failed to terminate ${sandboxUserName} processes: exit status ${String(result.status)}`);
-    }
+    const firstFailure = sweepSandboxUserProcessesOnce(signal);
+    const failure = firstFailure ? sweepSandboxUserProcessesOnce(signal) : undefined;
+    if (failure) failures.push(`pkill -${signal}: ${failure}`);
   }
+  // Fail closed: a submission can exhaust the PID cgroup so this `sudo` cannot even be spawned,
+  // and a spawned `sudo` can still fail to run `pkill` (e.g. fork failure inside sudo).
+  // Reporting success would leave its processes alive for the next request on this instance.
+  if (failures.length > 0) {
+    throw new Error(`failed to terminate ${sandboxUserName} processes: ${failures.join('; ')}`);
+  }
+}
+
+/**
+ * Runs one `pkill` sweep and returns a failure description, or `undefined` on success. Retried once
+ * by the caller because a sweep can itself be killed by a concurrent watchdog sweep
+ * ({@link startSandboxTimeoutWatchdog}'s `pkill -KILL` matches it).
+ */
+function sweepSandboxUserProcessesOnce(signal: 'TERM' | 'KILL'): string | undefined {
+  const result = runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName as string]);
+  if (result.error) return result.error.message;
+  if (result.status === null) return `terminated by ${result.signal ?? 'an unknown signal'}`;
+  if (result.status === 0) return undefined;
+  // `sudo` exits with 1 both when `pkill` matched no process (a success, silent on stderr) and on
+  // its own failures (auth/permission problems, fork/exec failure — all reported on stderr), so
+  // status alone cannot distinguish them.
+  const stderr = result.stderr.toString().trim();
+  if (result.status === 1 && !stderr) return undefined;
+  return `exit status ${result.status}${stderr ? ` (${stderr})` : ''}`;
 }
 
 /**

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -185,45 +185,66 @@ export function makeAccessibleToSandboxUser(targetPath: string): void {
  * sandbox process is safe because the judge server handles one request at a time. The default
  * sends SIGTERM immediately followed by SIGKILL (final cleanup); callers that want a grace period
  * send `['TERM']`, wait, and then send `['KILL']`.
+ *
+ * Fails closed: after SIGKILL, throws when a sandbox process is still alive (e.g. a submission
+ * exhausted the PID cgroup so `sudo` cannot spawn). Reporting success would leave that process
+ * running next to the next request on this instance.
  */
 export function killSandboxUserProcesses(signals: readonly ('TERM' | 'KILL')[] = ['TERM', 'KILL']): void {
   if (!sandboxUserName) return;
   // One direct call per signal instead of one `sh -c 'pkill ...; pkill ...'`: the wrapping shell
   // would run as the sandbox user too, so the first pkill would kill it before the second ran.
-  // Their results are not inspected: `sudo` exits with 1 both when `pkill` matched nothing and on
+  // Exit statuses are not inspected: `sudo` exits with 1 both when `pkill` matched nothing and on
   // its own failures, and a sweep can itself be killed by a concurrent watchdog sweep
   // ({@link startSandboxTimeoutWatchdog}'s `pkill -KILL` matches it). What matters is the outcome.
+  const spawnErrors: string[] = [];
   for (const signal of signals) {
-    runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName]);
+    const result = runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName]);
+    if (result.error) spawnErrors.push(`pkill -${signal}: ${result.error.message}`);
   }
-  // Fail closed once SIGKILL was sent: a submission can exhaust the PID cgroup so the `sudo` above
-  // cannot even be spawned, and reporting success would leave its processes alive for the next
-  // request on this instance. After SIGTERM alone, survivors are expected (the caller grants a
-  // grace period before sending SIGKILL).
-  if (!signals.includes('KILL')) return;
+  if (!signals.includes('KILL')) {
+    // Survivors are expected during the caller's grace period, so only a sweep that never started
+    // is a failure here.
+    if (spawnErrors.length > 0) {
+      throw new Error(`failed to signal ${sandboxUserName} processes: ${spawnErrors.join('; ')}`);
+    }
+    return;
+  }
   const survivors = findSurvivingSandboxUserProcesses();
   if (survivors) throw new Error(`failed to terminate ${sandboxUserName} processes: ${survivors}`);
 }
 
 /**
  * Lists the sandbox user's live processes as the harness user (listing needs no privilege), or
- * `undefined` when none remain. Just-killed processes linger as zombies until reaped, so those are
- * ignored and the check is retried briefly.
+ * `undefined` when none remain. SIGKILL is re-sent between attempts: a child forked after `pkill`
+ * scanned `/proc` was never signalled, and a process in uninterruptible sleep dies only once its
+ * I/O completes. Just-killed processes linger as zombies until reaped; a zombie row is ignored only
+ * when it has a single thread, because a thread-group leader that exited via `pthread_exit` shows
+ * as a zombie while its other threads keep running.
  */
 function findSurvivingSandboxUserProcesses(): string | undefined {
   for (let attempt = 0; ; attempt++) {
-    const result = child_process.spawnSync('ps', ['-o', 'pid=,stat=,comm=', '-u', sandboxUserName as string], {
+    if (attempt > 0) {
+      runAsSandboxUser(['pkill', '-KILL', '-u', sandboxUserName as string]);
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
+    }
+    const result = child_process.spawnSync('ps', ['-o', 'pid=,stat=,nlwp=,comm=', '-u', sandboxUserName as string], {
       env: MINIMAL_ENV,
       encoding: 'utf8',
     });
+    // `ps` exits with 1 both when no process matched and on its own errors, which it reports on
+    // stderr; anything else is a failure to list, which must count as a failure to verify.
+    const stderr = result.stderr?.trim();
     if (result.error) return `cannot list processes: ${result.error.message}`;
+    if (result.signal || (result.status !== 0 && (result.status !== 1 || stderr))) {
+      return `cannot list processes: ${stderr || `ps exited with ${result.status ?? result.signal}`}`;
+    }
     const survivors = result.stdout
       .split('\n')
       .map((line) => line.trim())
-      .filter((line) => line && !/^\d+\s+Z/.test(line));
+      .filter((line) => line && !/^\d+\s+Z\S*\s+1\s/.test(line));
     if (survivors.length === 0) return undefined;
-    if (attempt >= 5) return survivors.join(', ');
-    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+    if (attempt >= 10) return survivors.join(', ');
   }
 }
 

--- a/src/helpers/sandboxUser.ts
+++ b/src/helpers/sandboxUser.ts
@@ -190,13 +190,17 @@ export function killSandboxUserProcesses(signals: readonly ('TERM' | 'KILL')[] =
   if (!sandboxUserName) return;
   // One direct call per signal instead of one `sh -c 'pkill ...; pkill ...'`: the wrapping shell
   // would run as the sandbox user too, so the first pkill would kill it before the second ran.
-  // Each `pkill` exits with 1 when no process matches, so ignore the exit status.
   for (const signal of signals) {
     const result = runAsSandboxUser(['pkill', `-${signal}`, '-u', sandboxUserName]);
-    // Fail closed: a submission can exhaust the PID cgroup so this `sudo` cannot even be spawned.
+    // Fail closed: a submission can exhaust the PID cgroup so this `sudo` cannot even be spawned,
+    // and a spawned `sudo` can still fail to run `pkill` (e.g. fork failure inside sudo).
     // Reporting success would leave its processes alive for the next request on this instance.
+    // `pkill` exits with 1 when no process matched, which is a success here.
     if (result.error) {
       throw new Error(`failed to terminate ${sandboxUserName} processes: ${result.error.message}`);
+    }
+    if (result.status !== 0 && result.status !== 1) {
+      throw new Error(`failed to terminate ${sandboxUserName} processes: exit status ${String(result.status)}`);
     }
   }
 }


### PR DESCRIPTION
## Customer Summary

- When a learner's program is stopped after a run, the judge now double-checks that nothing of it is still running before serving the next request, instead of assuming the stop command worked. This prevents a misbehaving program from lingering into another learner's run on the same server.
- No visible change for learners; runs that clean up normally behave exactly as before.

## Technical Summary

- `killSandboxUserProcesses` (`src/helpers/sandboxUser.ts`) sends the requested signals through `sudo pkill` best-effort — sudo's exit status 1 is ambiguous (pkill no-match vs. sudo's own auth/fork/exec failures) and a sweep can itself be killed by an in-flight watchdog `pkill -KILL` — and then verifies the outcome. After a SIGKILL sweep, `findSurvivingSandboxUserProcesses` lists the sandbox user's processes as the harness user with `ps -o pid=,stat=,nlwp=,comm= -u <user>` (no privilege needed), ignores only single-threaded zombie rows, re-sends `pkill -KILL` and waits 100 ms between up to 10 further attempts, and throws only when a live process remains or `ps` cannot verify (spawn error, signal termination, exit status above 1, or exit 1 with diagnostics).
- A `['TERM']`-only sweep throws only when its `sudo` could not be spawned, after all requested signals were attempted, so a caller's later SIGKILL sweep is never skipped by a mid-loop throw.

## Why

- Issue #306: `killSandboxUserProcesses` inspected only `result.error`, so a `sudo` that started but failed to run `pkill` (e.g. fork failure under PID-cgroup exhaustion) was reported as success. Checking exit statuses turned out to be unsound (sudo's exit 1 is ambiguous; benign sudo warnings on stderr would have failed every routine sweep), so the function now verifies the post-condition instead.
- The fork-free termination mechanism proposed in #306 (`cgroup.kill` or a privileged reaper) needs judge-container privilege changes and is intentionally out of scope; a PID-exhausted instance now fails loudly instead of silently.

## Testing

- `bun run verify` and `bun run verify-full` passed (the sudo/`ps` path itself only runs on the Linux judge image with `EXERCODE_SANDBOX_USER` set).
- Multi-agent review (review-booster, 5 rounds): all findings fixed; the final round reported no findings.
