### PR TITLE
feat: support externally built command judges

### DIFF
--- a/example/external_build/judge.ts
+++ b/example/external_build/judge.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+
+import { DecisionCode, runCommandInTemporaryPackageManagerProject } from '@exercode/problem-utils';
+import { commandJudgePreset } from '@exercode/problem-utils/presets/command';
+
+await commandJudgePreset(import.meta.dirname, {
+  buildSubmission: false,
+  readTestCases: () => Promise.resolve([{ id: 'external_build' }]),
+  runCommand: ({ cwd, env, timeLimitSeconds }) =>
+    runCommandInTemporaryPackageManagerProject({
+      cwd,
+      projectDir: path.join(import.meta.dirname, 'judge_project'),
+      packageManager: 'npm',
+      prepareDependencies: false,
+      command: ['node', '-e', String.raw`process.stdout.write("built externally\n")`],
+      env,
+      timeLimitSeconds,
+    }),
+  test: ({ runResult }) =>
+    runResult.stdout === 'built externally\n' ? undefined : { decisionCode: DecisionCode.WRONG_ANSWER },
+});

--- a/example/external_build/judge_project/package.json
+++ b/example/external_build/judge_project/package.json
@@ -1,0 +1,5 @@
+{
+  "scripts": {
+    "prepare": "node -e \"process.exit(23)\""
+  }
+}

--- a/example/external_build/model_answers/default/Main.kt
+++ b/example/external_build/model_answers/default/Main.kt
@@ -1,0 +1,1 @@
+this source is built only by the external build system

--- a/example/external_build/problem.md
+++ b/example/external_build/problem.md
@@ -1,0 +1,8 @@
+---
+name: External build
+timeLimitMs: 10000
+requiredSubmissionFilePaths:
+  - Main.kt
+---
+
+The custom runner owns the submission build and dependency preparation.

--- a/src/helpers/runCommandInTemporaryPackageManagerProject.ts
+++ b/src/helpers/runCommandInTemporaryPackageManagerProject.ts
@@ -37,6 +37,11 @@ export interface RunCommandInTemporaryPackageManagerProjectOptions {
   projectDir: string;
   packageManager: PackageManager;
   command: readonly [string, ...string[]] | ((context: { runDir: string }) => readonly [string, ...string[]]);
+  /**
+   * Set to false when `command` prepares the dependencies it needs.
+   * Defaults to true.
+   */
+  prepareDependencies?: boolean;
   stdin?: string;
   env?: NodeJS.ProcessEnv;
   timeLimitSeconds: number;
@@ -113,7 +118,8 @@ export async function runCommandInTemporaryPackageManagerProject(
     makeAccessibleToSandboxUser(runDir);
 
     const env = options.env ? { ...process.env, ...options.env } : process.env;
-    const installCommand = await resolveInstallCommand(options.packageManager, runDir);
+    const installCommand =
+      options.prepareDependencies === false ? undefined : await resolveInstallCommand(options.packageManager, runDir);
     const command = typeof options.command === 'function' ? options.command({ runDir }) : options.command;
     const startedAt = Date.now();
     const outputLimitBytes = options.outputLimitBytes ?? defaultOutputLimitBytes;

--- a/src/presets/command.ts
+++ b/src/presets/command.ts
@@ -74,6 +74,11 @@ export interface CommandJudgePresetOptions<
   TTestCase extends BaseCommandTestCase = BaseCommandTestCase,
   TRunResult extends CommandRunResult = CommandRunResult,
 > {
+  /**
+   * Set to false when the custom runner builds the submitted source itself.
+   * Defaults to true.
+   */
+  buildSubmission?: boolean;
   limits?: CommandJudgeLimits;
   runTimeoutSeconds?: number;
   readTestCases?: (problemDir: string) => Promise<readonly TTestCase[]>;
@@ -231,32 +236,34 @@ async function runCommandJudgeForCwd<
   const env = { ...process.env, CI: '', FORCE_COLOR: '0' };
 
   let mainFilePath = originalMainFilePath;
-  if (languageDefinition.prebuild) {
-    try {
-      await languageDefinition.prebuild(cwd);
-      const prebuiltMainFilePath = await findEntryPointFile(cwd, params.language);
-      if (prebuiltMainFilePath) mainFilePath = prebuiltMainFilePath;
-    } catch (error) {
-      printTestCaseResult({
-        testCaseId: prebuildTestCaseId,
-        decisionCode: DecisionCode.BUILD_ERROR,
-        stderr: error instanceof Error ? error.message : String(error),
-      });
-      return { allAccepted: false };
+  if (options.buildSubmission !== false) {
+    if (languageDefinition.prebuild) {
+      try {
+        await languageDefinition.prebuild(cwd);
+        const prebuiltMainFilePath = await findEntryPointFile(cwd, params.language);
+        if (prebuiltMainFilePath) mainFilePath = prebuiltMainFilePath;
+      } catch (error) {
+        printTestCaseResult({
+          testCaseId: prebuildTestCaseId,
+          decisionCode: DecisionCode.BUILD_ERROR,
+          stderr: error instanceof Error ? error.message : String(error),
+        });
+        return { allAccepted: false };
+      }
     }
-  }
 
-  const buildCommand = languageDefinition.buildCommand?.(mainFilePath);
-  if (buildCommand) {
-    const buildResult = runBuild(buildCommand, {
-      cwd,
-      env,
-      testCaseId: prebuildTestCaseId,
-      limits,
-    });
-    if (buildResult) {
-      printTestCaseResult(buildResult);
-      return { allAccepted: false };
+    const buildCommand = languageDefinition.buildCommand?.(mainFilePath);
+    if (buildCommand) {
+      const buildResult = runBuild(buildCommand, {
+        cwd,
+        env,
+        testCaseId: prebuildTestCaseId,
+        limits,
+      });
+      if (buildResult) {
+        printTestCaseResult(buildResult);
+        return { allAccepted: false };
+      }
     }
   }
 

--- a/test/e2e/debugAndJudge.test.ts
+++ b/test/e2e/debugAndJudge.test.ts
@@ -457,6 +457,24 @@ test.each<
     ],
   ],
   [
+    'example/external_build',
+    'judge.ts',
+    'model_answers/default',
+    {},
+    {},
+    [
+      {
+        testCaseId: 'external_build',
+        decisionCode: 2000,
+        exitStatus: 0,
+        stdin: '',
+        stdout: 'built externally\n',
+        timeSeconds: expect.any(Number),
+        memoryBytes: expect.any(Number),
+      },
+    ],
+  ],
+  [
     'example/gui_python_window',
     'judge.ts',
     'model_answers/default',


### PR DESCRIPTION
## Customer Summary

- Allow command judges with custom build systems to skip redundant submission builds and dependency preparation.
- Preserve the existing behavior when the new options are not specified.

## Technical Summary

- Add `buildSubmission` to `commandJudgePreset` options.
- Add `prepareDependencies` to temporary package-manager project options.
- Add an E2E fixture covering a runner that owns both steps.

## Why

Some command judges use their own build system to compile submitted source files and prepare dependencies. Running the shared preparation steps first duplicates work and increases execution time.

## Testing

- `bun run verify-full`
